### PR TITLE
Check `model_type` rather than enumerating supported models

### DIFF
--- a/curated_transformers/models/hf_util.py
+++ b/curated_transformers/models/hf_util.py
@@ -8,18 +8,12 @@ SUPPORTED_BERT_MODELS = ["bert-base-cased"]
 
 SUPPORTED_ROBERTA_MODELS = ["roberta-base", "xlm-roberta-base", "xlm-roberta-large"]
 
-SUPPORTED_HF_MODELS = [
-    "bert-base-cased",
-    "bert-base-german-cased",
-    "roberta-base",
-    "xlm-roberta-base",
-    "xlm-roberta-large",
-]
+SUPPORTED_MODEL_TYPES = ["bert", "roberta", "xlm-roberta"]
 
 
-def _check_supported_hf_models(model_name: str):
-    if model_name not in SUPPORTED_HF_MODELS:
-        raise ValueError(f"unsupported HF model {model_name}")
+def _check_supported_hf_models(model_type: str):
+    if model_type not in SUPPORTED_MODEL_TYPES:
+        raise ValueError(f"unsupported HF model type: {model_type}")
 
 
 def convert_hf_pretrained_model_parameters(
@@ -31,17 +25,15 @@ def convert_hf_pretrained_model_parameters(
     Returns the state_dict that can be directly loaded by our Transformer module.
     """
     model_name = hf_model.config.name_or_path
-    _check_supported_hf_models(model_name)
+    _check_supported_hf_models(hf_model.config.model_type)
 
     converters = {
-        "bert-base-cased": _convert_bert_base_state,
-        "bert-base-german-cased": _convert_bert_base_state,
-        "roberta-base": _convert_roberta_base_state,
-        "xlm-roberta-base": _convert_roberta_base_state,
-        "xlm-roberta-large": _convert_roberta_base_state,
+        "bert": _convert_bert_base_state,
+        "roberta": _convert_roberta_base_state,
+        "xlm-roberta": _convert_roberta_base_state,
     }
 
-    return converters[model_name](hf_model)
+    return converters[hf_model.config.model_type](hf_model)
 
 
 def _convert_bert_base_state(

--- a/curated_transformers/models/hf_util.py
+++ b/curated_transformers/models/hf_util.py
@@ -4,9 +4,6 @@ import re
 
 from .._compat import transformers
 
-SUPPORTED_BERT_MODELS = ["bert-base-cased"]
-
-SUPPORTED_ROBERTA_MODELS = ["roberta-base", "xlm-roberta-base", "xlm-roberta-large"]
 
 SUPPORTED_MODEL_TYPES = ["bert", "roberta", "xlm-roberta"]
 

--- a/curated_transformers/tests/models/test_hf_model.py
+++ b/curated_transformers/tests/models/test_hf_model.py
@@ -5,8 +5,7 @@ import torch
 from curated_transformers.models.hf_wrapper import roberta_encoder_from_pretrained_hf_model
 from curated_transformers.models.hf_wrapper import bert_encoder_from_pretrained_hf_model
 from curated_transformers._compat import has_hf_transformers, transformers
-from curated_transformers.models.hf_util import SUPPORTED_HF_MODELS, SUPPORTED_ROBERTA_MODELS
-from curated_transformers.models.hf_util import SUPPORTED_BERT_MODELS
+from curated_transformers.models.hf_util import SUPPORTED_BERT_MODELS, SUPPORTED_ROBERTA_MODELS
 # fmt: on
 
 

--- a/curated_transformers/tests/models/test_hf_model.py
+++ b/curated_transformers/tests/models/test_hf_model.py
@@ -5,13 +5,16 @@ import torch
 from curated_transformers.models.hf_wrapper import roberta_encoder_from_pretrained_hf_model
 from curated_transformers.models.hf_wrapper import bert_encoder_from_pretrained_hf_model
 from curated_transformers._compat import has_hf_transformers, transformers
-from curated_transformers.models.hf_util import SUPPORTED_BERT_MODELS, SUPPORTED_ROBERTA_MODELS
 # fmt: on
+
+
+BERT_TEST_MODELS = ["bert-base-cased"]
+ROBERTA_TEST_MODELS = ["roberta-base", "xlm-roberta-base"]
 
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
-@pytest.mark.parametrize("model_name", SUPPORTED_ROBERTA_MODELS)
+@pytest.mark.parametrize("model_name", ROBERTA_TEST_MODELS)
 def test_hf_load_roberta_weights(model_name):
     encoder = roberta_encoder_from_pretrained_hf_model(model_name)
     assert encoder
@@ -19,7 +22,7 @@ def test_hf_load_roberta_weights(model_name):
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
-@pytest.mark.parametrize("model_name", SUPPORTED_BERT_MODELS)
+@pytest.mark.parametrize("model_name", BERT_TEST_MODELS)
 def test_hf_load_bert_weights(model_name):
     encoder = bert_encoder_from_pretrained_hf_model(model_name)
     assert encoder
@@ -27,7 +30,7 @@ def test_hf_load_bert_weights(model_name):
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
-@pytest.mark.parametrize("model_name", SUPPORTED_BERT_MODELS)
+@pytest.mark.parametrize("model_name", BERT_TEST_MODELS)
 def test_bert_model_against_hf_transformers(model_name):
     encoder = bert_encoder_from_pretrained_hf_model(model_name)
     encoder.eval()
@@ -54,7 +57,7 @@ def test_bert_model_against_hf_transformers(model_name):
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
-@pytest.mark.parametrize("model_name", SUPPORTED_ROBERTA_MODELS)
+@pytest.mark.parametrize("model_name", ROBERTA_TEST_MODELS)
 def test_roberta_model_against_hf_transformers(model_name):
     encoder = roberta_encoder_from_pretrained_hf_model(model_name)
     encoder.eval()


### PR DESCRIPTION
Also move enumeration of test models to `test_hf_model` and remove `xlm-roberta-large`. Works the same as base and requires a lot of memory.