### PR TITLE
Remove dependency on 🤗 transformers

### DIFF
--- a/curated_transformers/models/roberta/config.py
+++ b/curated_transformers/models/roberta/config.py
@@ -5,7 +5,22 @@ from ..bert import BertConfig
 
 @dataclass
 class RobertaConfig(BertConfig):
-    # Same as BertConfig
-
-    def __init__(self, *args, **kwargs):
-        super(RobertaConfig, self).__init__(*args, **kwargs)
+    def __init__(
+        self,
+        *args,
+        layer_norm_eps=1e-05,
+        max_position_embeddings=514,
+        padding_idx=1,
+        type_vocab_size=1,
+        vocab_size=50265,
+        **kwargs
+    ):
+        super(RobertaConfig, self).__init__(
+            *args,
+            layer_norm_eps=layer_norm_eps,
+            max_position_embeddings=max_position_embeddings,
+            padding_idx=padding_idx,
+            type_vocab_size=type_vocab_size,
+            vocab_size=vocab_size,
+            **kwargs
+        )

--- a/curated_transformers/models/transformer_model.py
+++ b/curated_transformers/models/transformer_model.py
@@ -157,8 +157,3 @@ def transformer_model_forward(model: Model, docs: List[Doc], is_train: bool):
 def transformer_model_init(model: Model, X: List[Doc] = None, Y=None):
     model.layers[0].initialize(X, Y)
     return model
-
-
-# Not a real transformer, just a stub.
-def _stubformer(nO, nV):
-    return Embed(nO, nV)

--- a/curated_transformers/tests/models/test_hf_model.py
+++ b/curated_transformers/tests/models/test_hf_model.py
@@ -1,43 +1,62 @@
+from typing import Callable
+from dataclasses import dataclass
+from functools import partial
+from curated_transformers.models.bert import BertConfig, BertEncoder
+from curated_transformers.models.roberta.config import RobertaConfig
+from curated_transformers.models.roberta.encoder import RobertaEncoder
 import pytest
 import torch
+from torch.nn import Module
 
 # fmt: off
-from curated_transformers.models.hf_wrapper import roberta_encoder_from_pretrained_hf_model
-from curated_transformers.models.hf_wrapper import bert_encoder_from_pretrained_hf_model
+from curated_transformers.models.hf_wrapper import build_hf_transformer_encoder_v1, build_hf_encoder_loader
 from curated_transformers._compat import has_hf_transformers, transformers
 # fmt: on
 
 
-BERT_TEST_MODELS = ["bert-base-cased"]
-ROBERTA_TEST_MODELS = ["roberta-base", "xlm-roberta-base"]
+@dataclass
+class ModelConfig:
+    config: BertConfig
+    encoder: Callable[[BertConfig], Module]
+    hf_model_name: str
+
+
+TEST_MODELS = [
+    ModelConfig(BertConfig(vocab_size=28996), BertEncoder, "bert-base-cased"),
+    ModelConfig(RobertaConfig(), RobertaEncoder, "roberta-base"),
+    ModelConfig(RobertaConfig(vocab_size=250002), RobertaEncoder, "xlm-roberta-base"),
+]
+
+
+def encoder_from_config(config: ModelConfig):
+    encoder = config.encoder(config.config)
+    return build_hf_transformer_encoder_v1(
+        encoder, init=build_hf_encoder_loader(name=config.hf_model_name)
+    )
 
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
-@pytest.mark.parametrize("model_name", ROBERTA_TEST_MODELS)
-def test_hf_load_roberta_weights(model_name):
-    encoder = roberta_encoder_from_pretrained_hf_model(model_name)
-    assert encoder
+@pytest.mark.parametrize("model_config", TEST_MODELS)
+def test_hf_load_weights(model_config):
+    model = encoder_from_config(model_config)
+    assert model
 
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
-@pytest.mark.parametrize("model_name", BERT_TEST_MODELS)
-def test_hf_load_bert_weights(model_name):
-    encoder = bert_encoder_from_pretrained_hf_model(model_name)
-    assert encoder
-
-
-@pytest.mark.slow
-@pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
-@pytest.mark.parametrize("model_name", BERT_TEST_MODELS)
-def test_bert_model_against_hf_transformers(model_name):
-    encoder = bert_encoder_from_pretrained_hf_model(model_name)
+@pytest.mark.parametrize("model_config", TEST_MODELS)
+def test_model_against_hf_transformers(model_config):
+    model = encoder_from_config(model_config)
+    model.initialize()
+    encoder = model.shims[0]._model
     encoder.eval()
-    hf_encoder = transformers.AutoModel.from_pretrained(model_name)
+    hf_encoder = transformers.AutoModel.from_pretrained(model_config.hf_model_name)
     hf_encoder.eval()
 
-    hf_tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
+    hf_tokenizer = transformers.AutoTokenizer.from_pretrained(
+        model_config.hf_model_name
+    )
     tokenization = hf_tokenizer(
         ["This is a test.", "Let's match outputs"], padding=True, return_tensors="pt"
     )
@@ -48,32 +67,6 @@ def test_bert_model_against_hf_transformers(model_name):
     Y_encoder = encoder(X, attention_mask=attention_mask)
     Y_hf_encoder = hf_encoder(X, attention_mask=attention_mask)
 
-    assert torch.allclose(Y_encoder.last_hidden_state, Y_hf_encoder.last_hidden_state)
-
-    # Try to infer the attention mask from padding.
-    Y_encoder = encoder(X)
-    assert torch.allclose(Y_encoder.last_hidden_state, Y_hf_encoder.last_hidden_state)
-
-
-@pytest.mark.slow
-@pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
-@pytest.mark.parametrize("model_name", ROBERTA_TEST_MODELS)
-def test_roberta_model_against_hf_transformers(model_name):
-    encoder = roberta_encoder_from_pretrained_hf_model(model_name)
-    encoder.eval()
-    hf_encoder = transformers.AutoModel.from_pretrained(model_name)
-    hf_encoder.eval()
-
-    hf_tokenizer = transformers.AutoTokenizer.from_pretrained(model_name)
-    tokenization = hf_tokenizer(
-        ["This is a test.", "Let's match outputs"], padding=True, return_tensors="pt"
-    )
-    X = tokenization["input_ids"]
-    attention_mask = tokenization["attention_mask"]
-
-    # Test with the tokenizer's attention mask
-    Y_encoder = encoder(X, attention_mask=attention_mask)
-    Y_hf_encoder = hf_encoder(X, attention_mask=attention_mask)
     assert torch.allclose(Y_encoder.last_hidden_state, Y_hf_encoder.last_hidden_state)
 
     # Try to infer the attention mask from padding.

--- a/curated_transformers/tests/tokenization/test_sentencepiece_encoder.py
+++ b/curated_transformers/tests/tokenization/test_sentencepiece_encoder.py
@@ -1,16 +1,13 @@
 from cutlery import SentencePieceProcessor
+from functools import partial
 import numpy.testing
 from pathlib import Path
 import pytest
 import spacy
 from thinc.api import Ragged
 
-from curated_transformers.tokenization.sentencepiece_encoder import (
-    build_hf_sentencepiece_encoder,
-)
-from curated_transformers.tokenization.sentencepiece_encoder import (
-    build_sentencepiece_encoder,
-)
+from curated_transformers.tokenization.sentencepiece_encoder import build_sentencepiece_encoder
+from curated_transformers.tokenization.sentencepiece_encoder import build_hf_sentencepiece_encoder_loader
 from curated_transformers._compat import has_hf_transformers
 
 
@@ -39,7 +36,10 @@ def test_sentencepiece_encoder(toy_encoder):
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
 def test_sentencepiece_encoder_hf_model():
     nlp = spacy.blank("en")
-    encoder = build_hf_sentencepiece_encoder("xlm-roberta-base")
+    encoder = build_sentencepiece_encoder(
+        init=build_hf_sentencepiece_encoder_loader(name="xlm-roberta-base")
+    )
+    encoder.initialize()
 
     doc1 = nlp.make_doc("I saw a girl with a telescope.")
     doc2 = nlp.make_doc("Today we will eat poké bowl.")
@@ -64,8 +64,11 @@ def test_sentencepiece_encoder_hf_model():
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
 def test_sentencepiece_encoder_unsupported_hf_model():
+    encoder = build_sentencepiece_encoder(
+        init=build_hf_sentencepiece_encoder_loader(name="roberta-base")
+    )
     with pytest.raises(ValueError, match=r"not supported"):
-        build_hf_sentencepiece_encoder("roberta-base")
+        encoder.initialize()
 
 
 def test_serialize(toy_encoder):

--- a/curated_transformers/tests/tokenization/test_wordpiece_encoder.py
+++ b/curated_transformers/tests/tokenization/test_wordpiece_encoder.py
@@ -1,11 +1,12 @@
 from cutlery import SentencePieceProcessor, WordPieceProcessor
+from functools import partial
 import numpy.testing
 from pathlib import Path
 import pytest
 import spacy
 from thinc.api import Ragged
 
-from curated_transformers.tokenization.wordpiece_encoder import build_hf_wordpiece_encoder
+from curated_transformers.tokenization.wordpiece_encoder import build_hf_wordpiece_encoder_loader
 from curated_transformers.tokenization.wordpiece_encoder import build_wordpiece_encoder
 from curated_transformers._compat import has_hf_transformers
 
@@ -14,11 +15,15 @@ from curated_transformers._compat import has_hf_transformers
 def test_dir(request):
     return Path(request.fspath).parent
 
+
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
-def test_sentencepiece_encoder_hf_model():
+def test_wordpiece_encoder_hf_model():
     nlp = spacy.blank("en")
-    encoder = build_hf_wordpiece_encoder("bert-base-cased")
+    encoder = build_wordpiece_encoder(
+        init=build_hf_wordpiece_encoder_loader(name="bert-base-cased")
+    )
+    encoder.initialize()
 
     doc1 = nlp.make_doc("I saw a girl with a telescope.")
     doc2 = nlp.make_doc("Today we will eat poké bowl.")
@@ -36,15 +41,19 @@ def test_sentencepiece_encoder_hf_model():
 
     numpy.testing.assert_equal(encoding[1].lengths, [1, 1, 1, 1, 1, 3, 1, 1, 1])
     numpy.testing.assert_equal(
-        encoding[1].dataXd, [101, 3570, 1195, 1209, 3940, 185, 5926, 2744, 7329, 119, 102]
+        encoding[1].dataXd,
+        [101, 3570, 1195, 1209, 3940, 185, 5926, 2744, 7329, 119, 102],
     )
 
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
 def test_sentencepiece_encoder_unsupported_hf_model():
+    encoder = build_wordpiece_encoder(
+        init=build_hf_wordpiece_encoder_loader(name="roberta-base")
+    )
     with pytest.raises(ValueError, match=r"not supported"):
-        build_hf_wordpiece_encoder("roberta-base")
+        encoder.initialize()
 
 
 def test_serialize():
@@ -54,14 +63,23 @@ def test_serialize():
     encoder_bytes = encoder.to_bytes()
     encoder2 = build_wordpiece_encoder()
     encoder2.from_bytes(encoder_bytes)
-    assert encoder.attrs["wordpiece_processor"].to_list() == encoder2.attrs["wordpiece_processor"].to_list()
+    assert (
+        encoder.attrs["wordpiece_processor"].to_list()
+        == encoder2.attrs["wordpiece_processor"].to_list()
+    )
 
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
 def test_serialize_hf_model():
-    encoder = build_hf_wordpiece_encoder("bert-base-cased")
+    encoder = build_wordpiece_encoder(
+        init=build_hf_wordpiece_encoder_loader(name="bert-base-cased")
+    )
+    encoder.initialize()
     encoder_bytes = encoder.to_bytes()
     encoder2 = build_wordpiece_encoder()
     encoder2.from_bytes(encoder_bytes)
-    assert encoder.attrs["wordpiece_processor"].to_list() == encoder2.attrs["wordpiece_processor"].to_list()
+    assert (
+        encoder.attrs["wordpiece_processor"].to_list()
+        == encoder2.attrs["wordpiece_processor"].to_list()
+    )

--- a/curated_transformers/tokenization/sentencepiece_encoder.py
+++ b/curated_transformers/tokenization/sentencepiece_encoder.py
@@ -2,8 +2,10 @@ from typing import List, Optional, TypeVar
 from cutlery import SentencePieceProcessor
 from spacy.tokens import Doc, Span
 from thinc.api import Model, Ragged, deserialize_attr, serialize_attr
+from thinc.model import empty_init
 
 from .._compat import has_hf_transformers, transformers
+from ..util import registry
 
 
 InT = TypeVar("InT", List[Doc], List[Span])
@@ -23,32 +25,13 @@ def deserialize_my_custom_class(
     return SentencePieceProcessor.from_protobuf(value)
 
 
-def build_sentencepiece_encoder() -> Model[List[Doc], List[Ragged]]:
+def build_sentencepiece_encoder(init=empty_init) -> Model[List[Doc], List[Ragged]]:
     return Model(
         "sentencepiece_encoder",
         forward=sentencepiece_encoder_forward,
+        init=init,
         attrs={"sentencepiece_processor": SentencePieceProcessor()},
     )
-
-
-def build_hf_sentencepiece_encoder(
-    hf_model_name: Optional[str] = None, hf_model_revision: str = "main"
-) -> Model[List[Doc], List[Ragged]]:
-    if not has_hf_transformers:
-        raise ValueError("requires 🤗 transformers")
-
-    tokenizer = transformers.AutoTokenizer.from_pretrained(
-        hf_model_name, revision=hf_model_revision
-    )
-    if not isinstance(tokenizer, transformers.XLMRobertaTokenizerFast):
-        raise ValueError("Loading from this 🤗 tokenizer is not supported")
-
-    encoder = build_sentencepiece_encoder()
-    encoder.attrs["sentencepiece_processor"] = SentencePieceProcessor.from_file(
-        tokenizer.vocab_file
-    )
-
-    return encoder
 
 
 def sentencepiece_encoder_forward(model: Model, X: InT, is_train: bool):
@@ -77,3 +60,22 @@ def sentencepiece_encoder_forward(model: Model, X: InT, is_train: bool):
         )
 
     return pieces, lambda dY: []
+
+
+@registry.model_loaders("curated-transformers.HFSentencepieceLoader.v1")
+def build_hf_sentencepiece_encoder_loader(*, name, revision: str = "main"):
+    def load(model: Model, X: List[Doc] = None, Y=None):
+        if not has_hf_transformers:
+            raise ValueError("requires 🤗 transformers")
+
+        tokenizer = transformers.AutoTokenizer.from_pretrained(name, revision=revision)
+        if not isinstance(tokenizer, transformers.XLMRobertaTokenizerFast):
+            raise ValueError("Loading from this 🤗 tokenizer is not supported")
+
+        model.attrs["sentencepiece_processor"] = SentencePieceProcessor.from_file(
+            tokenizer.vocab_file
+        )
+
+        return model
+
+    return load

--- a/curated_transformers/util.py
+++ b/curated_transformers/util.py
@@ -1,0 +1,4 @@
+import thinc
+
+thinc.registry.create("model_loaders")
+registry = thinc.registry


### PR DESCRIPTION
Before we this change, we would always load the model weights using the `transformers` library, even when deserializing finetuned models. This change postpones model loading to the `init` callback of the piece and transformer encoder models. In this way, we only attempt to load models when a new pipeline is initialized.

To further remove the dependency on the `transformers` library, we make the actual loader configurable through the new `model_loaders` registry. This allows us to provide other loaders in the future. This is an example configuration of a transformer pipe using the model loader mechanism:

```
[components.transformer]
factory = "curated_transformer"

[components.transformer.model]
@architectures = "curated-transformers.XLMRTransformer.v1"
vocab_size = 250002

[components.transformer.model.encoder_loader]
@model_loaders = "curated-transformers.HFEncoderLoader.v1"
name = "xlm-roberta-base"

[components.transformer.model.piecer_loader]
@model_loaders = "curated-transformers.HFSentencepieceLoader.v1"
name = "xlm-roberta-base"

[components.transformer.model.with_spans]
@architectures = "curated-transformers.WithStridedSpans.v1"
stride = 96
window = 128
```

Since we cannot rely on the `transformers` library anymore to provide a model's hyperparameters, we use the default hyperparameters for a model instead. The configuration should specify deviations from the default configuration, typically the vocab size, hidden size, number of layers, and number of attention heads.