### PR TITLE
Add support for the ALBERT encoder (Lan et al., 2019)

### DIFF
--- a/curated_transformers/models/__init__.py
+++ b/curated_transformers/models/__init__.py
@@ -1,3 +1,4 @@
+from .activations import GeluNew
 from .roberta.encoder import RobertaEncoder
 from .transformer_model import build_xlmr_transformer_model_v1
 from .transformer_model import build_bert_transformer_model_v1

--- a/curated_transformers/models/activations.py
+++ b/curated_transformers/models/activations.py
@@ -1,0 +1,21 @@
+import math
+import torch
+from torch import Tensor
+from torch.nn import Module
+
+
+class GeluNew(Module):
+    """GELU approximation, called `gelu_new` in many transformer models."""
+
+    def forward(self, input: Tensor):
+        return (
+            0.5
+            * input
+            * (
+                1.0
+                + torch.tanh(
+                    math.sqrt(2.0 / math.pi)
+                    * (input + 0.044715 * torch.pow(input, 3.0))
+                )
+            )
+        )

--- a/curated_transformers/models/albert/__init__.py
+++ b/curated_transformers/models/albert/__init__.py
@@ -1,0 +1,2 @@
+from .config import AlbertConfig, AlbertLayerConfig
+from .encoder import AlbertEncoder, AlbertLayerGroup

--- a/curated_transformers/models/albert/config.py
+++ b/curated_transformers/models/albert/config.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+
+from ..bert import BertConfig, BertAttentionConfig, BertEmbeddingConfig
+from ..bert import BertLayerConfig
+
+
+@dataclass
+class AlbertLayerConfig(BertLayerConfig):
+    inner_group_num: int
+    num_hidden_groups: int
+
+    def __init__(self, *args, inner_group_num=1, num_hidden_groups=1, **kwargs):
+        super(AlbertLayerConfig, self).__init__(*args, **kwargs)
+        self.inner_group_num = inner_group_num
+        self.num_hidden_groups = num_hidden_groups
+
+
+@dataclass
+class AlbertConfig(BertConfig):
+    layer: AlbertLayerConfig
+
+    def __init__(
+        self,
+        *,
+        embedding_size: int = 128,
+        hidden_size: int = 768,
+        inner_group_num: int = 1,
+        intermediate_size: int = 3072,
+        num_attention_heads: int = 12,
+        num_hidden_layers: int = 12,
+        num_hidden_groups: int = 1,
+        attention_probs_dropout_prob: float = 0.0,
+        hidden_dropout_prob: float = 0.0,
+        hidden_act: str = "gelu_new",
+        vocab_size: int = 30000,
+        type_vocab_size: int = 2,
+        max_position_embeddings: int = 512,
+        model_max_length: int = 512,
+        layer_norm_eps: float = 1e-12,
+        padding_idx: int = 0,
+    ):
+        self.embedding = BertEmbeddingConfig(
+            embedding_dim=embedding_size,
+            vocab_size=vocab_size,
+            type_vocab_size=type_vocab_size,
+            max_position_embeddings=max_position_embeddings,
+            layer_norm_eps=layer_norm_eps,
+            dropout_prob=hidden_dropout_prob,
+        )
+        self.attention = BertAttentionConfig(
+            hidden_size=hidden_size,
+            num_attention_heads=num_attention_heads,
+            dropout_prob=attention_probs_dropout_prob,
+        )
+        self.layer = AlbertLayerConfig(
+            hidden_size=hidden_size,
+            inner_group_num=inner_group_num,
+            intermediate_size=intermediate_size,
+            num_hidden_layers=num_hidden_layers,
+            num_hidden_groups=num_hidden_groups,
+            hidden_act=hidden_act,
+            layer_norm_eps=layer_norm_eps,
+            dropout_prob=hidden_dropout_prob,
+        )
+        self.model_max_length = model_max_length
+        self.padding_idx = padding_idx

--- a/curated_transformers/models/albert/layer_group.py
+++ b/curated_transformers/models/albert/layer_group.py
@@ -1,0 +1,27 @@
+from typing import List
+from torch import Tensor
+from torch.nn import Module, ModuleList
+
+from ..bert.config import BertAttentionConfig
+from ..bert.layer import BertAttentionConfig, BertEncoderLayer
+from .config import AlbertLayerConfig
+
+
+class AlbertLayerGroup(Module):
+    def __init__(
+        self, layer_config: AlbertLayerConfig, attention_config: BertAttentionConfig
+    ) -> None:
+        super().__init__()
+
+        self.group_layers = ModuleList(
+            [
+                BertEncoderLayer(layer_config, attention_config)
+                for _ in range(layer_config.inner_group_num)
+            ]
+        )
+
+    def forward(self, input: Tensor, **kwargs) -> Tensor:
+        layer_output = input
+        for layer in self.group_layers:
+            layer_output = layer(layer_output, **kwargs)
+        return layer_output

--- a/curated_transformers/models/bert/layer.py
+++ b/curated_transformers/models/bert/layer.py
@@ -1,10 +1,10 @@
-import math
 from typing import Optional
 
 import torch
 from torch.nn import Module
 from torch import Tensor
 
+from .. import GeluNew
 from ..attention import ScaledDotProductAttention
 from .config import BertAttentionConfig, BertLayerConfig
 
@@ -97,6 +97,12 @@ class BertFeedForward(Module):
             self.activation = torch.nn.ReLU()  # type: ignore
         elif config.hidden_act == "gelu":
             self.activation = torch.nn.GELU()  # type: ignore
+        elif config.hidden_act == "gelu_new":
+            # Ideally, we would use torch.nn.GELU(approximate="tanh"). However,
+            # the differences between that and the manual Torch implementation
+            # are large enough to fail tests comparing output to HF
+            # transformers.
+            self.activation = GeluNew()  # type: ignore
         else:
             raise ValueError(f"unsupported activation function '{config.hidden_act}")
 

--- a/curated_transformers/models/transformer_model.py
+++ b/curated_transformers/models/transformer_model.py
@@ -6,6 +6,7 @@ from thinc.layers import chain, Embed, with_array, with_padded
 from thinc.model import Model, empty_init
 from thinc.types import Ragged, ArrayXd
 
+from ..models.albert import AlbertConfig, AlbertEncoder
 from ..models.bert import BertConfig, BertEncoder
 from ..models.roberta import RobertaConfig, RobertaEncoder
 from ..tokenization.sentencepiece_adapters import build_xlmr_adapter, remove_bos_eos
@@ -14,6 +15,54 @@ from ..tokenization.wordpiece_encoder import build_wordpiece_encoder
 from .hf_wrapper import (
     build_hf_transformer_encoder_v1,
 )
+
+
+def build_albert_transformer_model_v1(
+    *,
+    vocab_size,
+    with_spans,
+    attention_probs_dropout_prob: float = 0.0,
+    embedding_size=128,
+    hidden_act: str = "gelu_new",
+    hidden_dropout_prob: float = 0.0,
+    hidden_size: int = 768,
+    intermediate_size: int = 3072,
+    layer_norm_eps: float = 1e-12,
+    max_position_embeddings: int = 512,
+    model_max_length: int = 512,
+    num_attention_heads: int = 12,
+    num_hidden_groups: int = 1,
+    num_hidden_layers: int = 12,
+    padding_idx: int = 0,
+    type_vocab_size: int = 2,
+):
+    config = AlbertConfig(
+        embedding_size=embedding_size,
+        hidden_size=hidden_size,
+        intermediate_size=intermediate_size,
+        num_attention_heads=num_attention_heads,
+        num_hidden_groups=num_hidden_groups,
+        num_hidden_layers=num_hidden_layers,
+        attention_probs_dropout_prob=attention_probs_dropout_prob,
+        hidden_dropout_prob=hidden_dropout_prob,
+        hidden_act=hidden_act,
+        vocab_size=vocab_size,
+        type_vocab_size=type_vocab_size,
+        max_position_embeddings=max_position_embeddings,
+        model_max_length=model_max_length,
+        layer_norm_eps=layer_norm_eps,
+        padding_idx=padding_idx,
+    )
+    encoder = AlbertEncoder(config)
+
+    piece_encoder = build_sentencepiece_encoder()
+    transformer = build_hf_transformer_encoder_v1(encoder)
+
+    return build_transformer_model_v1(
+        with_spans=with_spans,
+        piece_encoder=piece_encoder,
+        transformer=transformer,
+    )
 
 
 def build_bert_transformer_model_v1(

--- a/curated_transformers/tests/models/albert/test_encoder.py
+++ b/curated_transformers/tests/models/albert/test_encoder.py
@@ -1,0 +1,9 @@
+import pytest
+
+from curated_transformers.models.albert import AlbertConfig, AlbertEncoder
+
+
+def test_rejects_incorrect_number_of_groups():
+    config = AlbertConfig(num_hidden_groups=5)
+    with pytest.raises(ValueError, match=r"must be divisable"):
+        AlbertEncoder(config)

--- a/curated_transformers/tests/models/test_hf_model.py
+++ b/curated_transformers/tests/models/test_hf_model.py
@@ -1,6 +1,8 @@
 from typing import Callable
 from dataclasses import dataclass
 from functools import partial
+from curated_transformers.models.albert import AlbertEncoder
+from curated_transformers.models.albert.config import AlbertConfig
 from curated_transformers.models.bert import BertConfig, BertEncoder
 from curated_transformers.models.roberta.config import RobertaConfig
 from curated_transformers.models.roberta.encoder import RobertaEncoder
@@ -22,6 +24,7 @@ class ModelConfig:
 
 
 TEST_MODELS = [
+    ModelConfig(AlbertConfig(vocab_size=30000), AlbertEncoder, "albert-base-v2"),
     ModelConfig(BertConfig(vocab_size=28996), BertEncoder, "bert-base-cased"),
     ModelConfig(RobertaConfig(), RobertaEncoder, "roberta-base"),
     ModelConfig(RobertaConfig(vocab_size=250002), RobertaEncoder, "xlm-roberta-base"),


### PR DESCRIPTION
My main motivation for adding this model is that it adds a lot of flexibility compared to BERT:

- The embedding size is decoupled from the hidden size.
- Multiple layers can be grouped, sharing parameters.
- A group can have multiple layers.

Altogether, this makes the ALBERT model a good target for model distillation.