### PR TITLE
Add support for post-training dynamic quantization

### DIFF
--- a/curated_transformers/cli/quantize.py
+++ b/curated_transformers/cli/quantize.py
@@ -1,0 +1,97 @@
+from io import BytesIO
+from pathlib import Path
+import spacy
+from spacy import Language
+from spacy.cli import app
+from thinc.api import Model, PyTorchShim
+import torch
+from torch.nn import Embedding, Linear, Module
+from torch.quantization import qconfig
+from typer import Argument as Arg, Option
+
+from ..models.torchscript_wrapper import to_torchscript_wrapper
+from ..pipe import Transformer
+
+
+@app.command("quantize-transformer")
+def quantize_cli(
+    model_path: Path = Arg(..., help="Model to quantize", exists=True, allow_dash=True),
+    output_path: Path = Arg(..., help="Output directory to store quantized model in"),
+    skip_embeds: bool = Option(
+        False, "--skip-embeds", help="Do not quantize embeddings"
+    ),
+    skip_linear: bool = Option(
+        False, "--skip-linear", help="Do not quantize linear layers"
+    ),
+):
+    """
+    Quantize a curated-transformers model.
+    """
+    nlp = spacy.load(model_path)
+    nlp_quantize_dynamic(nlp, skip_embeds=skip_embeds, skip_linear=skip_linear)
+    nlp.to_disk(output_path)
+
+
+def size_of_model(model):
+    filelike = BytesIO()
+    torch.save(model.state_dict(), filelike)
+    return filelike.tell()
+
+
+def nlp_quantize_dynamic(
+    nlp: Language, *, skip_embeds: bool = False, skip_linear: bool = False
+):
+    for pipe_name, pipe in nlp.components:
+        # We only quantize curated transformers, other models may not
+        # be able to deal with quantization and/or TorchScript.
+        if not isinstance(pipe, Transformer):
+            continue
+
+        model = pipe.model.get_ref("transformer")
+
+        if model.name == "pytorch_script":  # Probably already quantized.
+            continue
+
+        before_size = size_of_model(pytorch_model(model))
+        quantize_dynamic(model, skip_embeds=skip_embeds, skip_linear=skip_linear)
+        after_size = size_of_model(pytorch_model(model))
+        print(
+            f"Quantized model in pipe '{pipe_name}' ({before_size/2**20:.1f} MiB -> {after_size/2**20:.1f} MiB)"
+        )
+
+        pipe.model.replace_node(model, to_torchscript_wrapper(model))
+        nlp.config["components"][pipe_name]["model"]["torchscript"] = True
+
+
+def quantize_dynamic(
+    model: Model, skip_embeds: bool = False, skip_linear: bool = False
+):
+    assert model.name == "pytorch"
+    assert isinstance(model.shims[0], PyTorchShim)
+
+    pytorch_model = model.shims[0]._model
+    quantize_types = {}
+
+    if not skip_linear:
+        quantize_types[Linear] = qconfig.default_dynamic_qconfig
+
+    if not skip_embeds:
+        quantize_types[Embedding] = qconfig.float_qparams_weight_only_qconfig
+
+    pytorch_model = torch.quantization.quantize_dynamic(
+        pytorch_model,
+        quantize_types,
+        dtype=torch.qint8,
+    )
+
+    model.shims[0]._model = pytorch_model
+
+
+def pytorch_model(model: Model) -> Module:
+    if model.name != "pytorch":
+        raise ValueError("Cannot extract PyTorch model from f{model.name}")
+
+    if not isinstance(model.shims[0], PyTorchShim):
+        raise ValueError("Model does not hold a PyTorchShim")
+
+    return model.shims[0]._model

--- a/curated_transformers/models/attention.py
+++ b/curated_transformers/models/attention.py
@@ -4,6 +4,8 @@ import torch
 from torch import Tensor
 from torch.nn import Module
 
+
+
 # https://www.tensorflow.org/text/tutorials/transformer#scaled_dot_product_attention
 class ScaledDotProductAttention(Module):
     def __init__(self, *, dropout_prob: float = 0.1):
@@ -27,7 +29,9 @@ class ScaledDotProductAttention(Module):
         # Replace tokens that we don't want to attend to with a large
         # negative value to zero them out during softmax normalization.
         if attn_mask is not None:
-            attn_scores += (1.0 - attn_mask) * torch.finfo(attn_scores.dtype).min
+            # The value is `torch.finfo(attn_scores.dype).min`. Unfortunately,
+            # we cannot use `torch.finfo` in TorchScript.
+            attn_scores += (1.0 - attn_mask) * -3.4028234663852886e38
 
         attn_weights = attn_scores.softmax(dim=-1)
         attn_values = self.dropout(attn_weights @ v)

--- a/curated_transformers/models/bert/encoder.py
+++ b/curated_transformers/models/bert/encoder.py
@@ -1,5 +1,4 @@
-from dataclasses import dataclass
-from typing import Optional, List
+from typing import Optional
 
 import torch
 from torch.nn import Module

--- a/curated_transformers/models/output.py
+++ b/curated_transformers/models/output.py
@@ -1,9 +1,10 @@
 from typing import List
 from dataclasses import dataclass
+import torch
 from torch import Tensor
 
 
-@dataclass
+@torch.jit.script
 class TransformerEncoderOutput:
     # The first element is the output of the embedding layer with shape [batch, seq, emb_dim].
     # The rest of the elements are the hidden states of each encoder layer respectively with shape [batch, seq, model_hidden].
@@ -30,4 +31,4 @@ class TransformerEncoderOutput:
 
     @property
     def last_hidden_state(self) -> Tensor:
-        return self.all_outputs[len(self.all_outputs) - 1]
+        return self.all_outputs[-1]

--- a/curated_transformers/models/torchscript_wrapper.py
+++ b/curated_transformers/models/torchscript_wrapper.py
@@ -1,0 +1,148 @@
+from typing import Any, Callable, Optional, Union
+from io import BytesIO
+import srsly
+from thinc.api import Model, PyTorchGradScaler, PyTorchShim, get_torch_default_device
+from thinc.layers.pytorchwrapper import convert_pytorch_default_inputs
+from thinc.layers.pytorchwrapper import convert_pytorch_default_outputs
+from thinc.layers.pytorchwrapper import forward
+import torch
+from torch.jit import ScriptModule
+from torch.nn import Module
+
+
+class TorchScriptShim(PyTorchShim):
+    """A Thinc shim that wraps a TorchScript module.
+
+    model:
+        The TorchScript module. A value of `None` is also possible to
+        construct a shim to deserialize into.
+    mixed_precision:
+        Enable mixed-precision. This changes whitelisted ops to run
+        in half precision for better performance and lower memory use.
+    grad_scaler:
+        The gradient scaler to use for mixed-precision training. If this
+        argument is set to "None" and mixed precision is enabled, a gradient
+        scaler with the default configuration is used.
+    device:
+        The PyTorch device to run the model on. When this argument is
+        set to "None", the default device for the currently active Thinc
+        ops is used.
+    """
+
+    def __init__(
+        self,
+        model: Optional[ScriptModule],
+        config=None,
+        optimizer: Any = None,
+        mixed_precision: bool = False,
+        grad_scaler: Optional[PyTorchGradScaler] = None,
+        device: Optional["torch.device"] = None,
+    ):
+        if not isinstance(model, ScriptModule) and model is not None:
+            raise ValueError(
+                "PyTorchScriptShim must be initialized with ScriptModule or None (for deserialization)"
+            )
+
+        super().__init__(model, config, optimizer, mixed_precision, grad_scaler, device)
+
+    def to_bytes(self):
+        filelike = BytesIO()
+        torch.jit.save(self._model, filelike)
+        filelike.seek(0)
+        model_bytes = filelike.getvalue()
+        msg = {"config": self.cfg, "model": model_bytes}
+        return srsly.msgpack_dumps(msg)
+
+    def from_bytes(self, bytes_data):
+        device = get_torch_default_device()
+        msg = srsly.msgpack_loads(bytes_data)
+        self.cfg = msg["config"]
+        filelike = BytesIO(msg["model"])
+        filelike.seek(0)
+        self._model = torch.jit.load(filelike, map_location=device)
+        self._model.to(device)
+        self._grad_scaler.to_(device)
+        return self
+
+
+def TorchScriptWrapper_v1(
+    model: Optional[ScriptModule] = None,
+    convert_inputs: Optional[Callable] = None,
+    convert_outputs: Optional[Callable] = None,
+    mixed_precision: bool = False,
+    grad_scaler: Optional[PyTorchGradScaler] = None,
+    device: Optional["torch.device"] = None,
+) -> Model[Any, Any]:
+    """Wrap a TorchScript model, so that it has the same API as Thinc models.
+
+    model:
+        The TorchScript module. A value of `None` is also possible to
+        construct a shim to deserialize into.
+    mixed_precision:
+        Enable mixed-precision. This changes whitelisted ops to run
+        in half precision for better performance and lower memory use.
+    grad_scaler:
+        The gradient scaler to use for mixed-precision training. If this
+        argument is set to "None" and mixed precision is enabled, a gradient
+        scaler with the default configuration is used.
+    device:
+        The PyTorch device to run the model on. When this argument is
+        set to "None", the default device for the currently active Thinc
+        ops is used.
+    """
+
+    if convert_inputs is None:
+        convert_inputs = convert_pytorch_default_inputs
+    if convert_outputs is None:
+        convert_outputs = convert_pytorch_default_outputs
+
+    return Model(
+        "pytorch_script",
+        forward,
+        attrs={"convert_inputs": convert_inputs, "convert_outputs": convert_outputs},
+        shims=[
+            TorchScriptShim(
+                model=model,
+                mixed_precision=mixed_precision,
+                grad_scaler=grad_scaler,
+                device=device,
+            )
+        ],
+        dims={"nI": None, "nO": None},
+    )
+
+
+def to_torchscript_wrapper(model: Model):
+    """Convert a PyTorch wrapper to a TorchScript wrapper. The embedded PyTorch
+    `Module` is converted to `ScriptModule`.
+    """
+
+    if model.name != "pytorch":
+        raise ValueError(
+            "Only PyTorch wrappers can be converted to TorchScript wrappers"
+        )
+
+    shim = model.shims[0]
+    if not isinstance(shim, PyTorchShim):
+        raise ValueError("Expected PyTorchShim when converting a PyTorch wrapper")
+
+    convert_inputs = model.attrs["convert_inputs"]
+    convert_outputs = model.attrs["convert_outputs"]
+
+    pytorch_model = shim._model
+    if not isinstance(pytorch_model, Module):
+        raise ValueError("PyTorchShim does wrap a PyTorch module")
+
+    torchscript_model = torch.jit.script(pytorch_model)
+    grad_scaler = shim._grad_scaler
+    mixed_precision = shim._mixed_precision
+    device = shim.device
+
+    return TorchScriptWrapper_v1(
+        torchscript_model,
+        convert_inputs=convert_inputs,
+        convert_outputs=convert_outputs,
+        mixed_precision=mixed_precision,
+        grad_scaler=grad_scaler,
+        device=device,
+    )

--- a/curated_transformers/tests/test_torchscript_wrapper.py
+++ b/curated_transformers/tests/test_torchscript_wrapper.py
@@ -1,0 +1,28 @@
+import pytest
+import numpy
+from torch.nn import Linear
+from thinc.layers import PyTorchWrapper_v2
+
+from curated_transformers.models.torchscript_wrapper import (
+    TorchScriptWrapper_v1,
+    to_torchscript_wrapper,
+)
+
+
+@pytest.mark.parametrize("nN,nI,nO", [(2, 3, 4)])
+def test_pytorch_script(nN, nI, nO):
+
+    model = PyTorchWrapper_v2(Linear(nI, nO)).initialize()
+
+    script_model = to_torchscript_wrapper(model)
+
+    X = numpy.random.randn(nN, nI).astype("f")
+    Y = model.predict(X)
+    Y_script = script_model.predict(X)
+    numpy.testing.assert_allclose(Y, Y_script)
+
+    serialized = script_model.to_bytes()
+    script_model2 = TorchScriptWrapper_v1()
+    script_model2.from_bytes(serialized)
+
+    numpy.testing.assert_allclose(Y, script_model2.predict(X))

--- a/project/project.yml
+++ b/project/project.yml
@@ -22,6 +22,7 @@ workflows:
     - preprocess
     - create-config
     - train
+    - quantize
     - evaluate
 
 commands:
@@ -51,7 +52,7 @@ commands:
       - 'cp configs/base-config.cfg configs/${vars.treebank}/config.cfg'
 
   - name: "train"
-    help: "Train the parser"
+    help: "Train the pipeline"
     script:
       - "python -m spacy train configs/${vars.treebank}/config.cfg --output training/${vars.treebank} --gpu-id ${vars.gpu} --nlp.lang=${vars.lang} --paths.train corpus/${vars.treebank}/train.spacy --paths.dev corpus/${vars.treebank}/dev.spacy"
     deps:
@@ -61,18 +62,31 @@ commands:
     outputs:
       - "training/${vars.treebank}/model-best"
 
-  - name: "evaluate"
-    help: "Evaluate the parser model on the test corpus."
+  - name: "quantize"
+    help: "Quantize the pipeline"
     script:
-      - "python -m spacy evaluate --gpu-id ${vars.gpu} training/${vars.treebank}/model-best corpus/${vars.treebank}/test.spacy"
+      - "python -m spacy quantize-transformer training/${vars.treebank}/model-best training/${vars.treebank}/model-best-quantized"
     deps:
       - "training/${vars.treebank}/model-best"
+    outputs:
+      - "training/${vars.treebank}/model-best-quantized"
+
+  - name: "evaluate"
+    help: "Evaluate the pipeline on the test corpus."
+    script:
+      - "python -m spacy evaluate --gpu-id ${vars.gpu} training/${vars.treebank}/model-best corpus/${vars.treebank}/test.spacy"
+      - "python -m spacy evaluate training/${vars.treebank}/model-best-quantized corpus/${vars.treebank}/test.spacy"
+    deps:
+      - "training/${vars.treebank}/model-best"
+      - "training/${vars.treebank}/model-best-quantized"
       - "corpus/${vars.treebank}/test.spacy"
 
   - name: "evaluate-dev"
-    help: "Evaluate the parser model on the test corpus."
+    help: "Evaluate the pipeline on the dev corpus."
     script:
       - "python -m spacy evaluate --gpu-id ${vars.gpu} training/${vars.treebank}/model-best corpus/${vars.treebank}/dev.spacy"
+      - "python -m spacy evaluate training/${vars.treebank}/model-best-quantized corpus/${vars.treebank}/dev.spacy"
     deps:
       - "training/${vars.treebank}/model-best"
+      - "training/${vars.treebank}/model-best-quantized"
       - "corpus/${vars.treebank}/dev.spacy"

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,9 @@ spacy_architectures =
     curated-transformers.WithStridedSpans.v1 = curated_transformers.models:build_with_strided_spans_v1
     curated-transformers.LastTransformerLayerListener.v1 = curated_transformers.pipe:last_transformer_layer_listener_v1
 
+spacy_cli =
+    curated-transformers.quantize = curated_transformers.cli.quantize:quantize_cli
+
 [bdist_wheel]
 universal = false
 


### PR DESCRIPTION
This change adds the following:

- `TorchScriptShim`/`TorchScriptWrapper_v1` to wrap TorchScript.
- A spaCy CLI extension that provides the `quantize-transformer`subcommand.

Besides that there are some modifications to the models:

- Use a constant for the attention mask so that the encoder can be converted to TorchScript. For some reason, this can also not be a global constant, so we have to inline the constant.
- Annotate `TransformerEncoderOutput` with `torch.jit.script`, so that it works with TorchScript.
- Extend the model factories with an `torchscript` option to force construction of TorchScript wrappers.