### PR TITLE
Wordpiece encoder: fix default EOS piece

### DIFF
--- a/curated_transformers/tokenization/wordpiece_encoder.py
+++ b/curated_transformers/tokenization/wordpiece_encoder.py
@@ -33,7 +33,7 @@ def build_wordpiece_encoder() -> Model[List[Doc], List[Ragged]]:
             "wordpiece_processor": WordPieceProcessor([]),
             "unk_piece": "[UNK]",
             "bos_piece": "[CLS]",
-            "eos_piece": "[SEP] ",
+            "eos_piece": "[SEP]",
         },
     )
 


### PR DESCRIPTION
This shouldn't matter much in practice, since we are overriding the piece when loading a model.