### PR TITLE
Refactor pipeline and listeners to propagate all Transformer outputs

### DIFF
--- a/curated_transformers/models/__init__.py
+++ b/curated_transformers/models/__init__.py
@@ -1,4 +1,6 @@
 from .activations import GeluNew
+from .albert.encoder import AlbertEncoder
+from .bert.encoder import BertEncoder
 from .hf_wrapper import build_hf_encoder_loader_v1
 from .roberta.encoder import RobertaEncoder
 from .transformer_model import (

--- a/curated_transformers/models/albert/encoder.py
+++ b/curated_transformers/models/albert/encoder.py
@@ -4,7 +4,7 @@ from torch.nn import Linear, Module
 from torch import Tensor
 
 from ..bert.embeddings import BertEmbeddings
-from ..output import TransformerEncoderOutput
+from ..output import PyTorchTransformerOutput
 from .config import AlbertConfig
 from .layer_group import AlbertLayerGroup
 
@@ -47,7 +47,7 @@ class AlbertEncoder(Module):
         input_ids: Tensor,
         attention_mask: Optional[Tensor] = None,
         token_type_ids: Optional[Tensor] = None,
-    ) -> TransformerEncoderOutput:
+    ) -> PyTorchTransformerOutput:
         """
         Shapes:
             input_ids, token_type_ids - (batch, seq_len)
@@ -73,6 +73,6 @@ class AlbertEncoder(Module):
             )
             layer_outputs.append(layer_output)
 
-        return TransformerEncoderOutput(
+        return PyTorchTransformerOutput(
             embedding_output=embeddings, layer_hidden_states=layer_outputs
         )

--- a/curated_transformers/models/bert/encoder.py
+++ b/curated_transformers/models/bert/encoder.py
@@ -7,7 +7,7 @@ from torch import Tensor
 from .config import BertConfig
 from .embeddings import BertEmbeddings
 from .layer import BertEncoderLayer
-from ..output import TransformerEncoderOutput
+from ..output import PyTorchTransformerOutput
 
 
 class BertEncoder(Module):
@@ -35,7 +35,7 @@ class BertEncoder(Module):
         input_ids: Tensor,
         attention_mask: Optional[Tensor] = None,
         token_type_ids: Optional[Tensor] = None,
-    ) -> TransformerEncoderOutput:
+    ) -> PyTorchTransformerOutput:
         """
         Shapes:
             input_ids, token_type_ids - (batch, seq_len)
@@ -56,6 +56,6 @@ class BertEncoder(Module):
             layer_output = layer(layer_output, attention_mask)
             layer_outputs.append(layer_output)
 
-        return TransformerEncoderOutput(
+        return PyTorchTransformerOutput(
             embedding_output=embeddings, layer_hidden_states=layer_outputs
         )

--- a/curated_transformers/models/hf_util.py
+++ b/curated_transformers/models/hf_util.py
@@ -1,9 +1,13 @@
-from typing import Dict
+from typing import Dict, Union
 import torch
 import re
 
 from .._compat import transformers
+from .albert import AlbertEncoder
+from .bert import BertEncoder
+from .roberta import RobertaEncoder
 
+SupportedHfTransformersT = Union[AlbertEncoder, BertEncoder, RobertaEncoder]
 
 SUPPORTED_MODEL_TYPES = ["albert", "bert", "roberta", "xlm-roberta"]
 

--- a/curated_transformers/models/output.py
+++ b/curated_transformers/models/output.py
@@ -1,11 +1,18 @@
-from typing import List
+from typing import List, TypeVar
 from dataclasses import dataclass
 import torch
 from torch import Tensor
 
+from thinc.types import Floats2d, Ragged
+
+
+TrfOutputT = TypeVar("TrfOutputT", Floats2d, Ragged)
+
 
 @torch.jit.script
-class TransformerEncoderOutput:
+class PyTorchTransformerOutput:
+    """Output of the PyTorch Transformer Encoders"""
+
     # The first element is the output of the embedding layer with shape [batch, seq, emb_dim].
     # The rest of the elements are the hidden states of each encoder layer respectively with shape [batch, seq, model_hidden].
     all_outputs: List[Tensor]
@@ -26,9 +33,68 @@ class TransformerEncoderOutput:
             return self.all_outputs[idx + 1]
         else:
             raise ValueError(
-                f"index must be >= 0 and < {len(self.all_outputs) - 1}, got {idx}"
+                f"Index must be >= 0 and < {len(self.all_outputs) - 1}, got {idx}"
             )
 
     @property
     def last_hidden_state(self) -> Tensor:
         return self.all_outputs[-1]
+
+    @property
+    def all_layer_hidden_states(self) -> List[Tensor]:
+        return self.all_outputs[1:]
+
+
+@dataclass
+class TransformerModelOutput:
+    """Wrapper for PyTorchTransformerOutput consumed by downstream non-PyTorch components.
+    Also acts as the accumulator for the outputs of subsequent models in the Transformer pipeline."""
+
+    # Non-padded, un-stacked versions of the outputs.
+    # The outer list tracks Docs/spans and the inner
+    # list tracks the embedding + layer outputs of each Doc/span.
+    #
+    # The inner-most element is a Floats2d when returned by
+    # the PyTorchWrapper transformer model, which are subsequently
+    # converted to Ragged by the models that follow.
+    all_outputs: List[List[TrfOutputT]]
+
+    # Set to True if only the last layer's outputs are preserved.
+    last_layer_only: bool
+
+    def __init__(self, *, outputs: List[List[TrfOutputT]]) -> None:
+        self.all_outputs = outputs
+
+    @property
+    def embedding_outputs(self) -> List[TrfOutputT]:
+        return [y[0] for y in self.all_outputs]
+
+    @property
+    def last_hidden_states(self) -> List[TrfOutputT]:
+        return [y[-1] for y in self.all_outputs]
+
+    @property
+    def all_layer_hidden_states(self) -> List[List[TrfOutputT]]:
+        return [y[1:] for y in self.all_outputs]
+
+    @property
+    def num_outputs(self) -> int:
+        return len(self.all_outputs[0])
+
+
+@dataclass
+class DocTransformerOutput:
+    """Stored on Doc instances. Each Ragged element corresponds to a layer in
+    original TransformerModelOutput, containing piece identifiers."""
+
+    layer_outputs: List[Ragged]
+
+    # Set to True if only the last layer's outputs are preserved.
+    last_layer_only: bool
+
+    def __init__(self, *, layer_outputs: List[Ragged]) -> None:
+        self.layer_outputs = layer_outputs
+
+    @property
+    def last_hidden_state(self) -> Ragged:
+        return self.layer_outputs[-1]

--- a/curated_transformers/models/roberta/encoder.py
+++ b/curated_transformers/models/roberta/encoder.py
@@ -6,7 +6,7 @@ from torch.nn import Module
 from torch import Tensor
 
 from ..bert.layer import BertEncoderLayer
-from ..output import TransformerEncoderOutput
+from ..output import PyTorchTransformerOutput
 from .embeddings import RobertaEmbeddings
 from .config import RobertaConfig
 
@@ -35,7 +35,7 @@ class RobertaEncoder(Module):
         input_ids: Tensor,
         attention_mask: Optional[Tensor] = None,
         token_type_ids: Optional[Tensor] = None,
-    ) -> TransformerEncoderOutput:
+    ) -> PyTorchTransformerOutput:
         """
         Shapes:
             input_ids, token_type_ids - (batch, seq_len)
@@ -56,6 +56,6 @@ class RobertaEncoder(Module):
             layer_output = layer(layer_output, attention_mask)
             layer_outputs.append(layer_output)
 
-        return TransformerEncoderOutput(
+        return PyTorchTransformerOutput(
             embedding_output=embeddings, layer_hidden_states=layer_outputs
         )

--- a/curated_transformers/models/with_strided_spans.py
+++ b/curated_transformers/models/with_strided_spans.py
@@ -1,7 +1,14 @@
-from typing import Callable, List, Tuple
+from typing import Callable, List, Tuple, Union
 from functools import partial
 from thinc.model import Model
 from thinc.types import Ragged, Floats2d, Ints1d
+
+from .output import TransformerModelOutput
+
+# In case of a single list, each element corresponds to a single document/span.
+# For nested lists, each inner list corresponds to a single document/span.
+RaggedInOutT = Union[List[Ragged], List[List[Ragged]]]
+Floats2dInOutT = Union[List[Floats2d], List[List[Floats2d]]]
 
 
 def build_with_strided_spans_v1(stride=96, window=128):
@@ -10,7 +17,7 @@ def build_with_strided_spans_v1(stride=96, window=128):
 
 def with_strided_spans(
     layer, *, stride=96, window=128
-) -> Model[List[Ragged], List[Ragged]]:
+) -> Model[List[Ragged], TransformerModelOutput]:
     if not (window // 2 <= stride <= window):
         raise ValueError(
             f"Stride must be within [window / 2, window] ([{window // 2}, {window}]), was: {stride}"
@@ -47,14 +54,20 @@ def with_strided_spans_init(model: Model, X, Y):
 
 
 def with_strided_spans_forward(
-    model: Model[List[Ragged], List[Ragged]], X: List[Ragged], is_train: bool
+    model: Model[List[Ragged], TransformerModelOutput],
+    X: List[Ragged],
+    is_train: bool,
 ):
     stride: int = model.attrs["stride"]
     window: int = model.attrs["window"]
 
     spans, doc_lens = _ragged_to_strided_arrays(Xlr=X, stride=stride, window=window)
+    # Calculate once and use for all layer outputs.
+    doc_len_sums = [int(x.sum()) for x in doc_lens]
 
     Y_layer, backprop_layer = model.layers[0](spans, is_train=is_train)
+    if not isinstance(Y_layer, TransformerModelOutput):
+        raise ValueError(f"Unsupported input of type '{type(Y_layer)}'")
 
     # Suppose we have:
     #
@@ -66,23 +79,30 @@ def with_strided_spans_forward(
     # ensure that there is no drift in representations, we
     # average them in both representations.
     _apply_to_overlaps(
-        Y_layer, doc_lens, stride=stride, window=window, func=_average_arrays
+        Y_layer.all_outputs,
+        doc_len_sums,
+        stride=stride,
+        window=window,
+        func=_average_arrays,
     )
 
-    Y_docs = _strided_arrays_to_ragged(
-        model, Y_layer, doc_lens, stride=stride, window=window
+    model_output = _strided_arrays_to_ragged(
+        model, Y_layer.all_outputs, doc_lens, doc_len_sums, stride=stride
     )
+    Y_layer.all_outputs = model_output
 
-    def backprop(dY):
+    def backprop(dY: RaggedInOutT):
         dY_spans, dY_lengths = _ragged_to_strided_arrays(
             dY, stride=stride, window=window
         )
+        # Calculate once and use for all layer outputs.
+        dY_length_sums = [int(x.sum()) for x in dY_lengths]
 
         # Both overlaps will have dY. However, the proper gradient is 0.5 * dY
         # since we averaged the overlaps in the forward pass.
         _apply_to_overlaps(
             dY_spans,
-            dY_lengths,
+            dY_length_sums,
             stride=stride,
             window=window,
             func=_normalize_gradients,
@@ -90,15 +110,15 @@ def with_strided_spans_forward(
 
         dXlf = backprop_layer(dY_spans)
         return _strided_arrays_to_ragged(
-            model, dXlf, dY_lengths, stride=stride, window=window
+            model, dXlf, dY_lengths, dY_length_sums, stride=stride
         )
 
-    return Y_docs, backprop
+    return Y_layer, backprop
 
 
 def _apply_to_overlaps(
-    Xlf: List[Floats2d],
-    lens: List[Ints1d],
+    Xlf: Floats2dInOutT,
+    len_sums: List[int],
     *,
     stride: int,
     window: int,
@@ -106,23 +126,36 @@ def _apply_to_overlaps(
 ):
     """Average representations of overlapping windows. This function
     modifies the arrays in Xlf in-place."""
+
+    def _apply_to_layer(input: List[Floats2d]):
+        for doc_len in len_sums:
+            prev_overlap = None
+            while doc_len != 0:
+                overlap = min(window - stride, doc_len)
+                if prev_overlap is not None:
+                    cur_overlap = input[0][:overlap]
+                    prev_overlap = prev_overlap[-overlap:]
+                    func(prev_overlap, cur_overlap)
+                prev_overlap = input[0][-overlap:]
+
+                doc_len -= min(stride, doc_len)
+                input = input[1:]
+
+    def _apply_to_layers(input: List[List[Floats2d]]):
+        # We need to transpose the input since the overlaps happen between
+        # each layer of each span, i.e., span 1 layer 1 overlaps with span 2 layer 1, etc.
+        transposed = list(zip(*input))
+        for x in transposed:
+            _apply_to_layer(x)
+
+    # Nothing to do if there is no overlap.
     if window - stride == 0:
-        # Nothing to do if there is no overlap.
         return
 
-    for Xr_lens in lens:
-        doc_len = int(Xr_lens.sum())
-        prev_overlap = None
-        while doc_len != 0:
-            overlap = min(window - stride, doc_len)
-            if prev_overlap is not None:
-                cur_overlap = Xlf[0][:overlap]
-                prev_overlap = prev_overlap[-overlap:]
-                func(prev_overlap, cur_overlap)
-            prev_overlap = Xlf[0][-overlap:]
-
-            doc_len -= min(stride, doc_len)
-            Xlf = Xlf[1:]
+    if isinstance(Xlf[0], list):
+        _apply_to_layers(Xlf)
+    else:
+        _apply_to_layer(Xlf)
 
 
 def _average_arrays(array1, array2):
@@ -137,32 +170,82 @@ def _normalize_gradients(array1, array2):
 
 
 def _ragged_to_strided_arrays(
-    Xlr: List[Ragged], *, stride: int, window: int
-) -> Tuple[List[Floats2d], List[List[int]]]:
-    spans = []
-    lens = []
-    for Xr in Xlr:
-        data = Xr.dataXd
-        lens.append(Xr.lengths)
-        while data.shape[0] != 0:
-            spans.append(data[:window])
-            data = data[stride:]
+    Xlr: RaggedInOutT, *, stride: int, window: int
+) -> Tuple[Floats2dInOutT, List[Ints1d]]:
+    """Convert the per-Doc Ragged sequences to an array of sub-sequences that span
+    all the input documents."""
 
-    return spans, lens
+    def _apply_to_layer(
+        input: Union[Tuple[Ragged], List[Ragged]], output: List[Floats2d]
+    ):
+        for Xr in input:
+            data = Xr.dataXd
+            while data.shape[0] != 0:
+                output.append(data[:window])
+                data = data[stride:]
+
+    def _apply_to_layers(input: List[List[Ragged]]):
+        # Transpose input to reconstruct strides across all documents.
+        transposed = list(zip(*Xlr))
+        spans = [[] for _ in range(len(transposed))]
+        lens = [x.lengths for x in transposed[0]]
+        for x, y in zip(transposed, spans):
+            _apply_to_layer(x, y)
+
+        # Normalize sequences as lists.
+        spans = [[y for y in x] for x in zip(*spans)]
+        return spans, lens
+
+    if isinstance(Xlr[0], list):
+        # Gradients in the backward pass.
+        # Shape of spans: (span, layer)
+        return _apply_to_layers(Xlr)
+    else:
+        # Inputs in the forward pass.
+        spans = []
+        lens = [x.lengths for x in Xlr]
+        _apply_to_layer(Xlr, spans)
+        return spans, lens
 
 
 def _strided_arrays_to_ragged(
-    model: Model, Xlf: List[Floats2d], lens: List[Ints1d], *, stride: int, window: int
-) -> List[Ragged]:
-    Xlr = []
-    for Xr_lens in lens:
-        doc_len = int(Xr_lens.sum())
-        arrs = []
-        while doc_len != 0:
-            arr = Xlf[0][: min(stride, doc_len)]
-            arrs.append(arr)
-            doc_len -= arr.shape[0]
-            Xlf = Xlf[1:]
-        Xlr.append(Ragged(model.ops.flatten(arrs), lengths=Xr_lens))
+    model: Model,
+    Xlf: Floats2dInOutT,
+    lens: List[Ints1d],
+    len_sums: List[int],
+    *,
+    stride: int,
+) -> RaggedInOutT:
+    """Inverse operation of _ragged_to_strided_arrays."""
 
-    return Xlr
+    def _apply_to_layer(
+        input: Union[Tuple[Floats2d], List[Floats2d]], output: List[Ragged]
+    ):
+        for doc_len, Xr_lens in zip(len_sums, lens):
+            arrs = []
+            while doc_len != 0:
+                arr = input[0][: min(stride, doc_len)]
+                arrs.append(arr)
+                doc_len -= arr.shape[0]
+                input = input[1:]
+            output.append(Ragged(model.ops.flatten(arrs), lengths=Xr_lens))
+
+    def _apply_to_layers(input: List[List[Floats2d]]):
+        # Transpose input to reconstruct strides across all documents.
+        transposed = list(zip(*input))
+        Xlr = [[] for _ in range(len(transposed))]
+        for x, y in zip(transposed, Xlr):
+            _apply_to_layer(x, y)
+
+        # Normalize sequences as lists.
+        Xlr = [[y for y in x] for x in zip(*Xlr)]
+        return Xlr
+
+    if isinstance(Xlf[0], list):
+        # Transformer output in forward pass.
+        return _apply_to_layers(Xlf)
+    else:
+        # Gradient from torch in backward pass.
+        Xlr = []
+        _apply_to_layer(Xlf, Xlr)
+        return Xlr

--- a/curated_transformers/tokenization/sentencepiece_adapters.py
+++ b/curated_transformers/tokenization/sentencepiece_adapters.py
@@ -1,5 +1,8 @@
-from typing import List
+from typing import List, Union
+
 from thinc.api import Model, Ragged
+
+from ..models.output import TransformerModelOutput
 
 _FAIRSEQ_OFFSET = 1
 _FAIRSEQ_BOS = 0
@@ -9,6 +12,8 @@ _FAIRSEQ_UNK = 3
 _SPP_BOS = 1
 _SPP_EOS = 2
 _SPP_UNK = 0
+
+RemoveBosEosBackpropInOutT = Union[List[Ragged], List[List[Ragged]]]
 
 
 def _update_to_fairseq(piece_id):
@@ -48,30 +53,45 @@ def xlmr_adapter_forward(model: Model, X: List[Ragged], is_train: bool):
     return X_xlmr, lambda dY: []
 
 
-def remove_bos_eos() -> Model[List[Ragged], List[Ragged]]:
+def remove_bos_eos() -> Model[TransformerModelOutput, TransformerModelOutput]:
     return Model("remove_bos_eos", remove_bos_eos_forward)
 
 
-def remove_bos_eos_forward(model: Model, X: List[Ragged], is_train: bool):
-    X_removed = [Xr[1:-1] for Xr in X]
+def remove_bos_eos_forward(model: Model, X: TransformerModelOutput, is_train: bool):
+    if not isinstance(X, TransformerModelOutput):
+        raise ValueError(f"Unsupported input of type '{type(X)}'")
 
-    def backprop(dY: List[Ragged]):
+    X.all_outputs = [[Xr[1:-1] for Xr in inner] for inner in X.all_outputs]
+
+    def backprop(dY: RemoveBosEosBackpropInOutT):
         # Pass-through dY, but add zero gradient for the special bos/eos
         # tokens.
+
+        def _apply_to_layer(input: List[Ragged], output: List[Ragged]):
+            for dYr in input:
+                dim0 = dYr.dataXd.shape[0] + 2
+
+                data = model.ops.xp.empty((dim0,) + dYr.dataXd.shape[1:], dtype="f")
+                data[[0, -1]] = 0.0
+                data[1:-1] = dYr.dataXd
+
+                lengths = model.ops.alloc1i(dYr.lengths.shape[0] + 2, zeros=False)
+                lengths[[0, -1]] = 1
+                lengths[1:-1] = dYr.lengths
+                output.append(Ragged(data, lengths=lengths))
+
+        def _apply_to_layers(input: List[List[Ragged]], output: List[List[Ragged]]):
+            for inner_dY in input:
+                inner_dX = []
+                _apply_to_layer(inner_dY, inner_dX)
+                output.append(inner_dX)
+
         dX = []
-        for dYr in dY:
-            dim0 = dYr.dataXd.shape[0] + 2
-
-            data = model.ops.xp.empty((dim0,) + dYr.dataXd.shape[1:], dtype="f")
-            data[[0, -1]] = 0.0
-            data[1:-1] = dYr.dataXd
-
-            lengths = model.ops.alloc1i(dYr.lengths.shape[0] + 2, zeros=False)
-            lengths[[0, -1]] = 1
-            lengths[1:-1] = dYr.lengths
-
-            dX.append(Ragged(data, lengths=lengths))
+        if isinstance(dY[0], list):
+            _apply_to_layers(dY, dX)
+        else:
+            _apply_to_layer(dY, dX)
 
         return dX
 
-    return X_removed, backprop
+    return X, backprop


### PR DESCRIPTION
Models that follow the transformer in the pipeline model chain operate on the outputs of all the transformer layers. This will allow for the usage of a separate listener that can pass a weighted sum of the former to the pooling layer (as opposed to using just the last layer's hidden state).