### PR TITLE
Fix import cycle between models and tokenization

### DIFF
--- a/curated_transformers/models/remove_eos_bos.py
+++ b/curated_transformers/models/remove_eos_bos.py
@@ -1,0 +1,51 @@
+from typing import List, Union
+from thinc.api import Model, Ragged
+
+from .output import TransformerModelOutput
+
+
+RemoveBosEosBackpropInOutT = Union[List[Ragged], List[List[Ragged]]]
+
+
+def remove_bos_eos() -> Model[TransformerModelOutput, TransformerModelOutput]:
+    return Model("remove_bos_eos", remove_bos_eos_forward)
+
+
+def remove_bos_eos_forward(model: Model, X: TransformerModelOutput, is_train: bool):
+    if not isinstance(X, TransformerModelOutput):
+        raise ValueError(f"Unsupported input of type '{type(X)}'")
+
+    X.all_outputs = [[Xr[1:-1] for Xr in inner] for inner in X.all_outputs]
+
+    def backprop(dY: RemoveBosEosBackpropInOutT):
+        # Pass-through dY, but add zero gradient for the special bos/eos
+        # tokens.
+
+        def _apply_to_layer(input: List[Ragged], output: List[Ragged]):
+            for dYr in input:
+                dim0 = dYr.dataXd.shape[0] + 2
+
+                data = model.ops.xp.empty((dim0,) + dYr.dataXd.shape[1:], dtype="f")
+                data[[0, -1]] = 0.0
+                data[1:-1] = dYr.dataXd
+
+                lengths = model.ops.alloc1i(dYr.lengths.shape[0] + 2, zeros=False)
+                lengths[[0, -1]] = 1
+                lengths[1:-1] = dYr.lengths
+                output.append(Ragged(data, lengths=lengths))
+
+        def _apply_to_layers(input: List[List[Ragged]], output: List[List[Ragged]]):
+            for inner_dY in input:
+                inner_dX = []
+                _apply_to_layer(inner_dY, inner_dX)
+                output.append(inner_dX)
+
+        dX = []
+        if isinstance(dY[0], list):
+            _apply_to_layers(dY, dX)
+        else:
+            _apply_to_layer(dY, dX)
+
+        return dX
+
+    return X, backprop

--- a/curated_transformers/models/transformer_model.py
+++ b/curated_transformers/models/transformer_model.py
@@ -15,7 +15,7 @@ from ..models.output import TransformerModelOutput
 from ..models.roberta import RobertaConfig, RobertaEncoder
 from ..models.torchscript_wrapper import TorchScriptWrapper_v1
 from ..tokenization.bbpe_encoder import build_byte_bpe_encoder
-from ..tokenization.sentencepiece_adapters import build_xlmr_adapter, remove_bos_eos
+from ..tokenization.sentencepiece_adapters import build_xlmr_adapter
 from ..tokenization.sentencepiece_encoder import build_sentencepiece_encoder
 from ..tokenization.wordpiece_encoder import build_wordpiece_encoder
 

--- a/curated_transformers/tests/tokenization/test_xlmr_adapter.py
+++ b/curated_transformers/tests/tokenization/test_xlmr_adapter.py
@@ -1,7 +1,7 @@
+from typing import List
 from cutlery import SentencePieceProcessor
 import numpy.testing
 from pathlib import Path
-from typing import List
 
 import numpy.testing
 import pytest
@@ -14,11 +14,11 @@ from curated_transformers.tokenization.sentencepiece_encoder import (
 )
 from curated_transformers.tokenization.sentencepiece_adapters import (
     build_xlmr_adapter,
-    remove_bos_eos,
 )
 from curated_transformers.tokenization.wordpiece_encoder import build_wordpiece_encoder
 from curated_transformers.tokenization.hf_loader import build_hf_piece_encoder_loader_v1
 from curated_transformers.models.output import TransformerModelOutput
+from curated_transformers.models.remove_eos_bos import remove_bos_eos
 
 
 @pytest.fixture(scope="module")

--- a/curated_transformers/tokenization/sentencepiece_adapters.py
+++ b/curated_transformers/tokenization/sentencepiece_adapters.py
@@ -1,8 +1,6 @@
-from typing import List, Union
+from typing import List
 
 from thinc.api import Model, Ragged
-
-from ..models.output import TransformerModelOutput
 
 _FAIRSEQ_OFFSET = 1
 _FAIRSEQ_BOS = 0
@@ -12,8 +10,6 @@ _FAIRSEQ_UNK = 3
 _SPP_BOS = 1
 _SPP_EOS = 2
 _SPP_UNK = 0
-
-RemoveBosEosBackpropInOutT = Union[List[Ragged], List[List[Ragged]]]
 
 
 def _update_to_fairseq(piece_id):
@@ -51,47 +47,3 @@ def xlmr_adapter_forward(model: Model, X: List[Ragged], is_train: bool):
         )
 
     return X_xlmr, lambda dY: []
-
-
-def remove_bos_eos() -> Model[TransformerModelOutput, TransformerModelOutput]:
-    return Model("remove_bos_eos", remove_bos_eos_forward)
-
-
-def remove_bos_eos_forward(model: Model, X: TransformerModelOutput, is_train: bool):
-    if not isinstance(X, TransformerModelOutput):
-        raise ValueError(f"Unsupported input of type '{type(X)}'")
-
-    X.all_outputs = [[Xr[1:-1] for Xr in inner] for inner in X.all_outputs]
-
-    def backprop(dY: RemoveBosEosBackpropInOutT):
-        # Pass-through dY, but add zero gradient for the special bos/eos
-        # tokens.
-
-        def _apply_to_layer(input: List[Ragged], output: List[Ragged]):
-            for dYr in input:
-                dim0 = dYr.dataXd.shape[0] + 2
-
-                data = model.ops.xp.empty((dim0,) + dYr.dataXd.shape[1:], dtype="f")
-                data[[0, -1]] = 0.0
-                data[1:-1] = dYr.dataXd
-
-                lengths = model.ops.alloc1i(dYr.lengths.shape[0] + 2, zeros=False)
-                lengths[[0, -1]] = 1
-                lengths[1:-1] = dYr.lengths
-                output.append(Ragged(data, lengths=lengths))
-
-        def _apply_to_layers(input: List[List[Ragged]], output: List[List[Ragged]]):
-            for inner_dY in input:
-                inner_dX = []
-                _apply_to_layer(inner_dY, inner_dX)
-                output.append(inner_dX)
-
-        dX = []
-        if isinstance(dY[0], list):
-            _apply_to_layers(dY, dX)
-        else:
-            _apply_to_layer(dY, dX)
-
-        return dX
-
-    return X, backprop


### PR DESCRIPTION
The cycle is fixed by moving `remove_eos_bos` to `curated_transformers.models`. Since this layer operates on transformer output, it seems like a better location anyway.