### PR TITLE
Add scalar weighting model and listener

### DIFF
--- a/curated_transformers/models/__init__.py
+++ b/curated_transformers/models/__init__.py
@@ -10,3 +10,4 @@ from .transformer_model import (
     build_xlmr_transformer_model_v1,
 )
 from .with_strided_spans import build_with_strided_spans_v1
+from .scalar_weight import build_scalar_weight_v1

--- a/curated_transformers/models/scalar_weight.py
+++ b/curated_transformers/models/scalar_weight.py
@@ -1,0 +1,125 @@
+from typing import List
+from thinc.layers.pytorchwrapper import PyTorchWrapper_v2
+from thinc.model import Model
+from thinc.types import ArgsKwargs, Ragged
+from thinc.shims.pytorch_grad_scaler import PyTorchGradScaler
+from thinc.util import torch2xp, xp2torch
+import torch
+from torch import Tensor
+from torch.nn import Module
+from spacy.util import SimpleFrozenDict
+
+from ..util import all_equal
+
+
+# From syntaxdot:
+# https://github.com/tensordot/syntaxdot/blob/22bd3d43ed2d7fcbef8a6217b01684194fae713f/syntaxdot-transformers/src/scalar_weighting.rs#L62
+class ScalarWeight(Module):
+    def __init__(self, *, num_layers: int, dropout_prob: float = 0.1):
+        super().__init__()
+
+        self.layer_weights = torch.nn.parameter.Parameter(torch.zeros(num_layers))
+        self.scale = torch.nn.parameter.Parameter(torch.tensor((1.0,)))
+        self.dropout_prob = dropout_prob
+
+    def forward(
+        self,
+        layer_outputs: Tensor,
+    ) -> Tensor:
+        """
+        Shapes:
+            layer_outputs - (seq_len, num_layers, layer_size)
+
+        Returns a weighted tensor of the input with shape (seq_len, layer_size).
+        """
+        if layer_outputs.shape[1] != self.layer_weights.shape[0]:
+            raise ValueError(
+                f"Expected {self.layer_weights.shape[0]} layers, got {layer_outputs.shape[1]} instead"
+            )
+
+        if self.training:
+            dropout_mask = torch.full_like(
+                self.layer_weights, 1.0 - self.dropout_prob
+            ).bernoulli()
+            softmask_mask = (1.0 - dropout_mask) * -10000.0
+            layer_weights = self.layer_weights + softmask_mask
+        else:
+            layer_weights = self.layer_weights
+
+        # Convert the layer weights into a probability distribution and
+        # expand dimensions to get shape [1, n_layers, 1].
+        layer_weights = layer_weights.softmax(dim=-1).unsqueeze(0).unsqueeze(-1)
+        weighted_layers = layer_outputs * layer_weights
+
+        return weighted_layers.sum(dim=-2, keepdim=False) * self.scale
+
+
+def build_scalar_weight_v1(
+    *,
+    num_layers: int,
+    dropout_prob: float = 0.1,
+    mixed_precision: bool = False,
+    grad_scaler_config: dict = SimpleFrozenDict(),
+) -> Model[List[Ragged], Ragged]:
+    if isinstance(grad_scaler_config, SimpleFrozenDict):
+        # Create a new, mutable dict instance.
+        grad_scaler_config = {}
+
+    if "enabled" not in grad_scaler_config:
+        grad_scaler_config["enabled"] = mixed_precision
+
+    # Increment number of layers by one to include the embedding layer.
+    scalar_weighting_layer = ScalarWeight(
+        num_layers=num_layers + 1, dropout_prob=dropout_prob
+    )
+
+    model = PyTorchWrapper_v2(
+        scalar_weighting_layer,
+        convert_inputs=_convert_inputs,
+        convert_outputs=_convert_outputs,
+        mixed_precision=mixed_precision,
+        grad_scaler=PyTorchGradScaler(**grad_scaler_config),
+    )
+
+    return model
+
+
+def _convert_inputs(model: Model, X: List[Ragged], is_train: bool = False):
+    ops = model.ops
+    layer_hidden_sizes = [x.data.shape[1] for x in X]
+    if not all_equal(layer_hidden_sizes):
+        raise ValueError(
+            f"Not all hidden sizes are equal in input passed to scalar weight"
+        )
+
+    Xt = ops.alloc3f(X[0].data.shape[0], len(X), X[0].data.shape[1])
+    for i, layer in enumerate(X):
+        Xt[:, i, :] = layer.dataXd
+    Xt = xp2torch(Xt, requires_grad=True)
+
+    def convert_from_torch_backward(d_inputs: ArgsKwargs):
+        # (seq, num_layers, hidden)
+        d_inputs: Tensor = d_inputs.args[0]
+
+        dX = []
+        for i in range(d_inputs.shape[1]):
+            dX_layer = d_inputs[:, i, :]
+            dX.append(Ragged(data=torch2xp(dX_layer, ops=ops), lengths=X[0].lengths))
+        return dX
+
+    output = ArgsKwargs(args=(Xt,), kwargs={})
+    return output, convert_from_torch_backward
+
+
+def _convert_outputs(model, inputs_outputs, is_train):
+    X, Yt = inputs_outputs
+    Y = Ragged(torch2xp(Yt, ops=model.ops), lengths=X[0].lengths)
+
+    def convert_for_torch_backward(dY):
+        dYt = xp2torch(dY.dataXd)
+        return ArgsKwargs(
+            args=(Yt,),
+            kwargs={"grad_tensors": dYt},
+        )
+
+    return Y, convert_for_torch_backward

--- a/curated_transformers/models/transformer_model.py
+++ b/curated_transformers/models/transformer_model.py
@@ -364,8 +364,7 @@ def _convert_inputs(
     max_model_seq_len=512,
     padding_idx: int = 1,
 ):
-    ops = get_current_ops()
-
+    ops = model.ops
     max_seq_len = max(x.size for x in X)
     if max_seq_len > max_model_seq_len:
         raise ValueError(
@@ -390,7 +389,7 @@ def _convert_inputs(
 
 def _convert_outputs(model, inputs_outputs, is_train):
     model_inputs, model_outputs = inputs_outputs
-    ops = get_current_ops()
+    ops = model.ops
     all_layer_outputs: bool = model.attrs["_all_layer_outputs"]
 
     # Strip the outputs for the padding timesteps
@@ -408,8 +407,7 @@ def _convert_outputs(model, inputs_outputs, is_train):
         ]
 
     Y = [[torch2xp(layer, ops=ops) for layer in output] for output in Yt]
-    output = TransformerModelOutput(outputs=Y)
-    output.last_layer_only = not all_layer_outputs
+    output = TransformerModelOutput(outputs=Y, last_layer_only=not all_layer_outputs)
 
     def convert_for_torch_backward(dY: List[List[Floats2d]]):
         Yt_flat = [y for inner in Yt for y in inner]

--- a/curated_transformers/tests/models/test_hf_model.py
+++ b/curated_transformers/tests/models/test_hf_model.py
@@ -70,8 +70,12 @@ def test_model_against_hf_transformers(model_config):
     Y_encoder = encoder(X, attention_mask=attention_mask)
     Y_hf_encoder = hf_encoder(X, attention_mask=attention_mask)
 
-    assert torch.allclose(Y_encoder.last_hidden_state, Y_hf_encoder.last_hidden_state)
+    assert torch.allclose(
+        Y_encoder.last_hidden_layer_states, Y_hf_encoder.last_hidden_state
+    )
 
     # Try to infer the attention mask from padding.
     Y_encoder = encoder(X)
-    assert torch.allclose(Y_encoder.last_hidden_state, Y_hf_encoder.last_hidden_state)
+    assert torch.allclose(
+        Y_encoder.last_hidden_layer_states, Y_hf_encoder.last_hidden_state
+    )

--- a/curated_transformers/tests/models/test_scalar_weight.py
+++ b/curated_transformers/tests/models/test_scalar_weight.py
@@ -1,0 +1,51 @@
+from thinc.api import NumpyOps, Ragged
+import torch
+
+from curated_transformers.models.scalar_weight import build_scalar_weight_v1
+
+
+def test_scalar_weight_model():
+    ops = NumpyOps()
+    model = build_scalar_weight_v1(num_layers=2, dropout_prob=0.0)
+
+    with torch.no_grad():
+        model.shims[0]._model.layer_weights[0] = 1
+        model.shims[0]._model.layer_weights[1] = 1
+        model.shims[0]._model.layer_weights[2] = 1
+
+    zeros = ops.alloc2f(15, 2)
+    ones = ops.alloc2f(15, 2) + 1
+
+    lens = ops.asarray1i([1, 2, 3, 4, 5])
+    X = [
+        Ragged(ones.copy(), lens.copy()),
+        Ragged(zeros.copy(), lens.copy()),
+        Ragged(ones.copy(), lens.copy()),
+    ]
+    Y = ops.alloc2f(15, 2) + (1.0 / 3.0) * 2
+
+    Yh, backprop = model(X, is_train=True)
+    ops.xp.testing.assert_equal(
+        Yh.dataXd,
+        Y,
+    )
+    ops.xp.testing.assert_equal(
+        Yh.lengths,
+        lens,
+    )
+
+    dX = backprop(
+        Ragged(ones.copy(), lengths=lens.copy()),
+    )
+    dX_expected = ops.alloc2f(15, 2) + (1.0 / 3.0)
+
+    assert len(dX) == 3
+    for dX_layer in dX:
+        ops.xp.testing.assert_equal(
+            dX_layer.dataXd,
+            dX_expected,
+        )
+        ops.xp.testing.assert_equal(
+            dX_layer.lengths,
+            lens,
+        )

--- a/curated_transformers/tests/models/test_transformer_model.py
+++ b/curated_transformers/tests/models/test_transformer_model.py
@@ -54,7 +54,7 @@ def test_xlmr_model(sample_docs, stride, window, hf_model):
     Y, backprop = model(sample_docs, is_train=False)
     assert isinstance(Y, TransformerModelOutput)
     num_ouputs = Y.num_outputs
-    Y = Y.last_hidden_states
+    Y = Y.last_hidden_layer_states
     assert len(Y) == 2
     numpy.testing.assert_equal(Y[0].lengths, [1, 1, 1, 1, 1, 1, 2, 2])
     assert Y[0].dataXd.shape == (10, hidden_size)
@@ -101,7 +101,7 @@ def test_input_with_spaces(sample_docs_with_spaces, stride, window, hf_model):
     Y, backprop = model(sample_docs_with_spaces, is_train=False)
     assert isinstance(Y, TransformerModelOutput)
     num_ouputs = Y.num_outputs
-    Y = Y.last_hidden_states
+    Y = Y.last_hidden_layer_states
     assert len(Y) == 2
     numpy.testing.assert_equal(Y[0].lengths, [1, 1, 1, 1, 1, 1, 1, 2, 2])
     assert Y[0].dataXd.shape == (11, hidden_size)

--- a/curated_transformers/tests/models/test_with_non_ws_tokens.py
+++ b/curated_transformers/tests/models/test_with_non_ws_tokens.py
@@ -26,7 +26,8 @@ def _mock_transformer() -> Model[List[Floats2d], TransformerModelOutput]:
                         )
                     ]
                     for x in X
-                ]
+                ],
+                last_layer_only=False,
             ),
             backprop,
         )

--- a/curated_transformers/tests/models/test_with_strided_spans.py
+++ b/curated_transformers/tests/models/test_with_strided_spans.py
@@ -31,7 +31,10 @@ def _add_range() -> Model[Floats2d, Floats2d]:
 
 def _mock_transformer() -> Model[List[Floats2d], TransformerModelOutput]:
     def forward(model: Model, X: List[Floats2d], is_train: bool):
-        return TransformerModelOutput(outputs=[[x] for x in X]), lambda x: x
+        return (
+            TransformerModelOutput(outputs=[[x] for x in X], last_layer_only=True),
+            lambda x: x,
+        )
 
     return Model("mock_transformer", forward)
 

--- a/curated_transformers/tests/test_pipe.py
+++ b/curated_transformers/tests/test_pipe.py
@@ -17,8 +17,12 @@ from curated_transformers.models.with_strided_spans import (
 from curated_transformers.pipe import make_transformer
 from curated_transformers._compat import has_hf_transformers, transformers
 
+from .util import make_tempdir
 
-cfg_string = """
+
+cfg_string_last_layer_listener = """
+    # LastTransformerLayerListener
+
     [nlp]
     lang = "en"
     pipeline = ["transformer","tagger"]
@@ -34,8 +38,56 @@ cfg_string = """
 
     [components.tagger.model.tok2vec]
     @architectures = "curated-transformers.LastTransformerLayerListener.v1"
-    width = 60
+    width = ${components.transformer.model.hidden_size}
     pooling = {"@layers":"reduce_mean.v1"}
+
+    [components.transformer]
+    factory = "curated_transformer"
+
+    [components.transformer.model]
+    @architectures = "curated-transformers.BertTransformer.v1"
+    vocab_size = 28996
+    num_hidden_layers = 1
+    hidden_size = 60
+
+    [components.transformer.model.with_spans]
+    @architectures = "curated-transformers.WithStridedSpans.v1"
+
+    [initialize]
+
+    [initialize.components]
+
+    [initialize.components.transformer]
+
+    [initialize.components.transformer.piecer_loader]
+    @model_loaders = "curated-transformers.HFPieceEncoderLoader.v1"
+    name = "bert-base-cased"
+"""
+
+cfg_string_scalar_weighting_layer_listener = """
+    # ScalarWeightingListener
+
+    [nlp]
+    lang = "en"
+    pipeline = ["transformer","tagger"]
+
+    [components]
+
+    [components.tagger]
+    factory = "tagger"
+
+    [components.tagger.model]
+    @architectures = "spacy.Tagger.v2"
+    nO = null
+
+    [components.tagger.model.tok2vec]
+    @architectures = "curated-transformers.ScalarWeightingListener.v1"
+    width = ${components.transformer.model.hidden_size}
+    pooling = {"@layers":"reduce_mean.v1"}
+
+    [components.tagger.model.tok2vec.weighting]
+    @architectures = "curated-transformers.ScalarWeight.v1"
+    num_layers = ${components.transformer.model.num_hidden_layers}
 
     [components.transformer]
     factory = "curated_transformer"
@@ -72,8 +124,7 @@ TRAIN_DATA = [
 ]
 
 
-@pytest.mark.slow
-def test_tagger():
+def create_and_train_tagger(cfg_string):
     config = Config().from_str(cfg_string)
     nlp = util.load_model_from_config(config, auto_fill=True, validate=True)
     tagger = nlp.get_pipe("tagger")
@@ -86,13 +137,28 @@ def test_tagger():
 
     optimizer = nlp.initialize(lambda: train_examples)
 
-    for i in range(5):
+    for _ in range(10):
         losses = {}
         nlp.update(train_examples, sgd=optimizer, losses=losses)
 
-    docs = list(nlp.pipe(["Eat blue ham", "I like green eggs"]))
+    return nlp
+
+
+def evaluate_tagger_on_train_data(model):
+    docs = list(model.pipe(["Eat blue ham", "I like green eggs"]))
     assert [t.tag_ for t in docs[0]] == ["V", "J", "N"]
     assert [t.tag_ for t in docs[1]] == ["N", "V", "J", "N"]
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
+@pytest.mark.parametrize(
+    "cfg_string",
+    [cfg_string_last_layer_listener, cfg_string_scalar_weighting_layer_listener],
+)
+def test_tagger(cfg_string):
+    model = create_and_train_tagger(cfg_string)
+    evaluate_tagger_on_train_data(model)
 
 
 def _hf_tokenize_per_token(tokenizer, docs, *, roberta=False):
@@ -170,7 +236,7 @@ def test_bert_transformer_pipe_against_hf():
     ):
         torch.testing.assert_allclose(
             hf_doc_encoding[:encoding_len][1:-1],
-            doc._.trf_data.last_hidden_state.dataXd,
+            doc._.trf_data.last_hidden_layer_state.dataXd,
         )
 
 
@@ -208,7 +274,7 @@ def test_roberta_transformer_pipe_against_hf():
     ):
         torch.testing.assert_allclose(
             hf_doc_encoding[:encoding_len][1:-1],
-            doc._.trf_data.last_hidden_state.dataXd,
+            doc._.trf_data.last_hidden_layer_state.dataXd,
         )
 
 
@@ -246,14 +312,14 @@ def test_xlmr_transformer_pipe_against_hf():
     ):
         torch.testing.assert_allclose(
             hf_doc_encoding[:encoding_len][1:-1],
-            doc._.trf_data.last_hidden_state.dataXd,
+            doc._.trf_data.last_hidden_layer_state.dataXd,
         )
 
 
 @pytest.mark.slow
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
 def test_frozen_transformer_pipe():
-    config = Config().from_str(cfg_string)
+    config = Config().from_str(cfg_string_scalar_weighting_layer_listener)
     nlp = util.load_model_from_config(config, auto_fill=True, validate=True)
     tagger = nlp.get_pipe("tagger")
     transformer = nlp.get_pipe("transformer")
@@ -310,9 +376,9 @@ def test_transformer_pipe_outputs():
     ]
     docs = list(pipe.pipe(docs))
     assert all([doc._.trf_data.last_layer_only for doc in docs]) == True
-    assert all([len(doc._.trf_data.layer_outputs) == 1 for doc in docs]) == True
+    assert all([len(doc._.trf_data.all_outputs) == 1 for doc in docs]) == True
 
     pipe = make_transformer(nlp, "transformer", model, all_layer_outputs=True)
     docs = list(pipe.pipe(docs))
     assert all([not doc._.trf_data.last_layer_only for doc in docs]) == True
-    assert all([len(doc._.trf_data.layer_outputs) == 12 + 1 for doc in docs]) == True
+    assert all([len(doc._.trf_data.all_outputs) == 12 + 1 for doc in docs]) == True

--- a/curated_transformers/tests/tokenization/test_xlmr_adapter.py
+++ b/curated_transformers/tests/tokenization/test_xlmr_adapter.py
@@ -39,7 +39,10 @@ def empty_encoder():
 
 def _mock_transformer() -> Model[List[Ragged], TransformerModelOutput]:
     def forward(model: Model, X: List[Ragged], is_train: bool):
-        return TransformerModelOutput(outputs=[[x] for x in X]), lambda x: x
+        return (
+            TransformerModelOutput(outputs=[[x] for x in X], last_layer_only=True),
+            lambda x: x,
+        )
 
     return Model("mock_transformer", forward)
 

--- a/curated_transformers/tests/util.py
+++ b/curated_transformers/tests/util.py
@@ -1,0 +1,11 @@
+import contextlib
+from pathlib import Path
+import shutil
+import tempfile
+
+
+@contextlib.contextmanager
+def make_tempdir():
+    d = Path(tempfile.mkdtemp())
+    yield d
+    shutil.rmtree(str(d))

--- a/curated_transformers/util.py
+++ b/curated_transformers/util.py
@@ -1,4 +1,5 @@
 from typing import List, Set
+import itertools
 import thinc
 
 thinc.registry.create("model_loaders", entry_points=True)
@@ -35,3 +36,10 @@ def batch_by_length(seqs, max_words: int) -> List[List[int]]:
     batches = [list(sorted(batch)) for batch in batches]
     batches.reverse()
     return batches
+
+
+def all_equal(iterable):
+    """Return True if all the elements are equal to each other
+    (or if the input is an empty sequence), False otherwise."""
+    g = itertools.groupby(iterable)
+    return next(g, True) and not next(g, False)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,9 @@ spacy_architectures =
     curated-transformers.RobertaTransformer.v1 = curated_transformers.models:build_roberta_transformer_model_v1
     curated-transformers.XLMRTransformer.v1 = curated_transformers.models:build_xlmr_transformer_model_v1
     curated-transformers.WithStridedSpans.v1 = curated_transformers.models:build_with_strided_spans_v1
+    curated-transformers.ScalarWeight.v1 = curated_transformers.models:build_scalar_weight_v1
     curated-transformers.LastTransformerLayerListener.v1 = curated_transformers.pipe:last_transformer_layer_listener_v1
+    curated-transformers.ScalarWeightingListener.v1 = curated_transformers.pipe:scalar_weighting_listener_v1
 
 spacy_cli =
     curated-transformers.quantize = curated_transformers.cli.quantize:quantize_cli


### PR DESCRIPTION
Field names in `PyTorchTransformerOutput`, `TransformerModelOutput` and `DocTransformerOutput` were additionally modified to reduce ambiguity.