### PR TITLE
Attention mask handling improvements

### DIFF
--- a/curated_transformers/models/__init__.py
+++ b/curated_transformers/models/__init__.py
@@ -1,4 +1,5 @@
 from .activations import GeluNew
+from .attention import AttentionMask
 from .albert.encoder import AlbertEncoder
 from .bert.encoder import BertEncoder
 from .hf_loader import build_hf_encoder_loader_v1

--- a/curated_transformers/models/albert/encoder.py
+++ b/curated_transformers/models/albert/encoder.py
@@ -3,6 +3,7 @@ import torch
 from torch.nn import Linear, Module
 from torch import Tensor
 
+from ..attention import AttentionMask
 from ..bert.embeddings import BertEmbeddings
 from ..output import PyTorchTransformerOutput
 from .config import AlbertConfig
@@ -39,13 +40,13 @@ class AlbertEncoder(Module):
             ]
         )
 
-    def _create_attention_mask(self, x: Tensor) -> Tensor:
-        return x.ne(self.padding_idx).int()
+    def _create_attention_mask(self, x: Tensor) -> AttentionMask:
+        return AttentionMask(bool_mask=x.ne(self.padding_idx))
 
     def forward(
         self,
         input_ids: Tensor,
-        attention_mask: Optional[Tensor] = None,
+        attention_mask: Optional[AttentionMask] = None,
         token_type_ids: Optional[Tensor] = None,
     ) -> PyTorchTransformerOutput:
         """
@@ -69,7 +70,7 @@ class AlbertEncoder(Module):
         layer_outputs = []
         for i in range(self.num_hidden_layers):
             layer_output = self.groups[i // layers_per_group](
-                layer_output, mask=attention_mask
+                layer_output, attn_mask=attention_mask
             )
             layer_outputs.append(layer_output)
 

--- a/curated_transformers/models/attention.py
+++ b/curated_transformers/models/attention.py
@@ -1,9 +1,36 @@
 from typing import Optional
+from dataclasses import dataclass
 import math
 import torch
 from torch import Tensor
 from torch.nn import Module
 
+
+@dataclass
+class AttentionMask:
+    bool_mask: Tensor
+    _logit_mask: Optional[Tensor] = None
+
+    def __post_init__(self):
+        if self.bool_mask.dtype != torch.bool:
+            raise ValueError(
+                f"attention mask of dtype torch.bool expected, was {self.bool_mask.dtype}"
+            )
+
+    @property
+    def logit_mask(self) -> Tensor:
+        if self._logit_mask is None:
+            # The value is `torch.finfo(attn_scores.dype).min`. Unfortunately,
+            # we cannot use `torch.finfo` in TorchScript.
+            self._logit_mask = (1.0 - self.bool_mask.int()) * -3.4028234663852886e38
+        return self._logit_mask
+
+    def dim(self):
+        return self.bool_mask.dim()
+
+    @property
+    def shape(self):
+        return self.bool_mask.shape
 
 
 # https://www.tensorflow.org/text/tutorials/transformer#scaled_dot_product_attention
@@ -13,7 +40,7 @@ class ScaledDotProductAttention(Module):
         self.dropout = torch.nn.Dropout(p=dropout_prob)
 
     def forward(
-        self, k: Tensor, q: Tensor, v: Tensor, attn_mask: Optional[Tensor] = None
+        self, k: Tensor, q: Tensor, v: Tensor, attn_mask: AttentionMask
     ) -> Tensor:
         """
         Shapes:
@@ -22,16 +49,19 @@ class ScaledDotProductAttention(Module):
         `attn_mask` indicates elements to attend to with `1` (and `0` otherwise)
         """
 
+        if attn_mask.dim() != 2:
+            raise ValueError(
+                f"attention mask dim mismatch, expected '2' but received {attn_mask.dim()}"
+            )
+
         model_dim = k.shape[-1]
         attn_scores = q @ k.transpose(-2, -1)
         attn_scores /= math.sqrt(model_dim)
 
         # Replace tokens that we don't want to attend to with a large
         # negative value to zero them out during softmax normalization.
-        if attn_mask is not None:
-            # The value is `torch.finfo(attn_scores.dype).min`. Unfortunately,
-            # we cannot use `torch.finfo` in TorchScript.
-            attn_scores += (1.0 - attn_mask) * -3.4028234663852886e38
+        batch, seq_len = attn_mask.shape
+        attn_scores += attn_mask.logit_mask.view(batch, 1, 1, seq_len)
 
         attn_weights = attn_scores.softmax(dim=-1)
         attn_values = self.dropout(attn_weights @ v)

--- a/curated_transformers/models/bert/encoder.py
+++ b/curated_transformers/models/bert/encoder.py
@@ -7,6 +7,7 @@ from torch import Tensor
 from .config import BertConfig
 from .embeddings import BertEmbeddings
 from .layer import BertEncoderLayer
+from ..attention import AttentionMask
 from ..output import PyTorchTransformerOutput
 
 
@@ -27,8 +28,8 @@ class BertEncoder(Module):
             ]
         )
 
-    def _create_attention_mask(self, x: Tensor) -> Tensor:
-        return x.ne(self.padding_idx).int()
+    def _create_attention_mask(self, x: Tensor) -> AttentionMask:
+        return AttentionMask(bool_mask=x.ne(self.padding_idx))
 
     def forward(
         self,
@@ -40,7 +41,7 @@ class BertEncoder(Module):
         Shapes:
             input_ids, token_type_ids - (batch, seq_len)
 
-        `attn_mask` indicates elements to attend to with `1` (and `0` otherwise)
+        `attention_mask` indicates elements to attend to with `True` (and `False` otherwise)
 
         Returns a tuple of consisting of a list of tensors from each Transformer
         layer and the sum of the input and positional embeddings.

--- a/curated_transformers/models/roberta/encoder.py
+++ b/curated_transformers/models/roberta/encoder.py
@@ -5,6 +5,7 @@ import torch
 from torch.nn import Module
 from torch import Tensor
 
+from ..attention import AttentionMask
 from ..bert.layer import BertEncoderLayer
 from ..output import PyTorchTransformerOutput
 from .embeddings import RobertaEmbeddings
@@ -27,13 +28,13 @@ class RobertaEncoder(Module):
             ]
         )
 
-    def _create_attention_mask(self, x: Tensor) -> Tensor:
-        return x.ne(self.padding_idx).int()
+    def _create_attention_mask(self, x: Tensor) -> AttentionMask:
+        return AttentionMask(x.ne(self.padding_idx))
 
     def forward(
         self,
         input_ids: Tensor,
-        attention_mask: Optional[Tensor] = None,
+        attention_mask: Optional[AttentionMask] = None,
         token_type_ids: Optional[Tensor] = None,
     ) -> PyTorchTransformerOutput:
         """

--- a/curated_transformers/tests/models/test_hf_model.py
+++ b/curated_transformers/tests/models/test_hf_model.py
@@ -1,19 +1,18 @@
 from typing import Callable
 from dataclasses import dataclass
-from curated_transformers.models.albert import AlbertEncoder
-from curated_transformers.models.albert.config import AlbertConfig
-from curated_transformers.models.bert import BertConfig, BertEncoder
-from curated_transformers.models.roberta.config import RobertaConfig
-from curated_transformers.models.roberta.encoder import RobertaEncoder
 import pytest
 import torch
 from torch.nn import Module
 
-# fmt: off
+from curated_transformers.models.albert import AlbertEncoder
+from curated_transformers.models.albert.config import AlbertConfig
+from curated_transformers.models.attention import AttentionMask
+from curated_transformers.models.bert import BertConfig, BertEncoder
+from curated_transformers.models.roberta.config import RobertaConfig
+from curated_transformers.models.roberta.encoder import RobertaEncoder
 from curated_transformers.models.hf_loader import build_hf_encoder_loader_v1
 from curated_transformers.models.transformer_model import _pytorch_encoder
 from curated_transformers._compat import has_hf_transformers, transformers
-# fmt: on
 
 
 @dataclass
@@ -67,7 +66,9 @@ def test_model_against_hf_transformers(model_config):
     attention_mask = tokenization["attention_mask"]
 
     # Test with the tokenizer's attention mask
-    Y_encoder = encoder(X, attention_mask=attention_mask)
+    Y_encoder = encoder(
+        X, attention_mask=AttentionMask(bool_mask=attention_mask.bool())
+    )
     Y_hf_encoder = hf_encoder(X, attention_mask=attention_mask)
 
     assert torch.allclose(Y_encoder.last_hidden_state, Y_hf_encoder.last_hidden_state)

--- a/curated_transformers/tests/test_pipe.py
+++ b/curated_transformers/tests/test_pipe.py
@@ -1,3 +1,4 @@
+from curated_transformers.models.attention import AttentionMask
 from curated_transformers.models.hf_loader import build_hf_encoder_loader_v1
 from curated_transformers.tokenization.hf_loader import build_hf_piece_encoder_loader_v1
 import pytest


### PR DESCRIPTION
- Add the `AttentionMask` class, which stores a boolean mask and creates a logit mask on-demand. The logit mask is cached to avoid recomputing it for every layer.
- Make the attention mask mandatory in internal classes.
- Move attention mask check and view logic to
`ScaledDotProductAttention.forward`.
- Fix inconsistent naming as `mask`.
