### PR TITLE
Split query, key, value differently for Torch compat

### DIFF
--- a/curated_transformers/models/bert/layer.py
+++ b/curated_transformers/models/bert/layer.py
@@ -58,7 +58,7 @@ class BertSelfAttention(Module):
         """
 
         proj = self.input(x)
-        k, q, v = proj.chunk(3, dim=-1)
+        q, k, v = proj.chunk(3, dim=-1)
 
         # (batch, head, seq_len, dims_per_head)
         k = self._split_heads(k)

--- a/curated_transformers/models/hf_util.py
+++ b/curated_transformers/models/hf_util.py
@@ -126,7 +126,7 @@ def _convert_albert_base_state(
     out["projection.weight"] = params["encoder.embedding_hidden_mapping_in.weight"]
     out["projection.bias"] = params["encoder.embedding_hidden_mapping_in.bias"]
 
-    return _merge_kqv_albert(out)
+    return _merge_qkv_albert(out)
 
 
 def _convert_bert_base_state(
@@ -173,7 +173,7 @@ def _convert_bert_base_state(
     out["embeddings.layer_norm.weight"] = params["embeddings.LayerNorm.weight"]
     out["embeddings.layer_norm.bias"] = params["embeddings.LayerNorm.bias"]
 
-    return _merge_kqv(out)
+    return _merge_qkv(out)
 
 
 def _convert_roberta_base_state(
@@ -220,10 +220,10 @@ def _convert_roberta_base_state(
     out["embeddings.inner.layer_norm.weight"] = params["embeddings.LayerNorm.weight"]
     out["embeddings.inner.layer_norm.bias"] = params["embeddings.LayerNorm.bias"]
 
-    return _merge_kqv(out)
+    return _merge_qkv(out)
 
 
-def _merge_kqv(params):
+def _merge_qkv(params):
     out = {}
     for name, parameter in params.items():
         m = re.match(
@@ -231,12 +231,12 @@ def _merge_kqv(params):
             name,
         )
         if m:
-            if "key" in name:
+            if "query" in name:
                 base = f"layers.{m['layer']}.mha"
                 out[f"{base}.input.{m['param_type']}"] = torch.cat(
                     [
                         parameter,
-                        params[f"{base}.query.{m['param_type']}"],
+                        params[f"{base}.key.{m['param_type']}"],
                         params[f"{base}.value.{m['param_type']}"],
                     ]
                 )
@@ -246,7 +246,7 @@ def _merge_kqv(params):
     return out
 
 
-def _merge_kqv_albert(params):
+def _merge_qkv_albert(params):
     out = {}
     for name, parameter in params.items():
         m = re.match(
@@ -254,12 +254,12 @@ def _merge_kqv_albert(params):
             name,
         )
         if m:
-            if "key" in name:
+            if "query" in name:
                 base = f"groups.{m['group']}.group_layers.{m['layer']}.mha"
                 out[f"{base}.input.{m['param_type']}"] = torch.cat(
                     [
                         parameter,
-                        params[f"{base}.query.{m['param_type']}"],
+                        params[f"{base}.key.{m['param_type']}"],
                         params[f"{base}.value.{m['param_type']}"],
                     ]
                 )


### PR DESCRIPTION
I messed up the chunking order in the previous PR. Fix it once again for Torch compat.
