### PR TITLE
Move embedding projection to BertEmbeddings

### DIFF
--- a/curated_transformers/models/albert/encoder.py
+++ b/curated_transformers/models/albert/encoder.py
@@ -27,10 +27,7 @@ class AlbertEncoder(Module):
                 f"Number of hidden layers ({self.num_hidden_layers}) must be divisable by number of hidden groups ({num_hidden_groups})"
             )
 
-        self.embeddings = BertEmbeddings(config.embedding)
-        self.projection = Linear(
-            config.embedding.embedding_dim, config.layer.hidden_size
-        )
+        self.embeddings = BertEmbeddings(config.embedding, config.layer)
 
         # Parameters are shared by groups of layers.
         self.groups = torch.nn.ModuleList(
@@ -62,7 +59,6 @@ class AlbertEncoder(Module):
             attention_mask = self._create_attention_mask(input_ids)
 
         embeddings = self.embeddings(input_ids, token_type_ids, None)
-        embeddings = self.projection(embeddings)
         layer_output = embeddings
 
         layers_per_group = self.num_hidden_layers // len(self.groups)

--- a/curated_transformers/models/bert/config.py
+++ b/curated_transformers/models/bert/config.py
@@ -88,6 +88,7 @@ class BertConfig:
     def __init__(
         self,
         *,
+        embedding_dim: int = 768,
         hidden_size: int = 768,
         intermediate_size: int = 3072,
         num_attention_heads: int = 12,
@@ -103,7 +104,7 @@ class BertConfig:
         padding_idx: int = 0,
     ):
         self.embedding = BertEmbeddingConfig(
-            embedding_dim=hidden_size,
+            embedding_dim=embedding_dim,
             vocab_size=vocab_size,
             type_vocab_size=type_vocab_size,
             max_position_embeddings=max_position_embeddings,

--- a/curated_transformers/models/bert/embeddings.py
+++ b/curated_transformers/models/bert/embeddings.py
@@ -1,31 +1,41 @@
 from typing import Optional
 import torch
 from torch import Tensor
-from torch.nn import Module
+from torch.nn import Dropout, Embedding, LayerNorm, Linear, Module
 
-from .config import BertEmbeddingConfig
+from .config import BertEmbeddingConfig, BertLayerConfig
 
 
 class BertEmbeddings(Module):
-    def __init__(self, config: BertEmbeddingConfig) -> None:
+    def __init__(
+        self, embedding_config: BertEmbeddingConfig, layer_config: BertLayerConfig
+    ) -> None:
         super().__init__()
 
-        self.word_embeddings = torch.nn.Embedding(
-            num_embeddings=config.vocab_size,
-            embedding_dim=config.embedding_dim,
+        self.word_embeddings = Embedding(
+            num_embeddings=embedding_config.vocab_size,
+            embedding_dim=embedding_config.embedding_dim,
         )
-        self.token_type_embeddings = torch.nn.Embedding(
-            num_embeddings=config.type_vocab_size, embedding_dim=config.embedding_dim
+        self.token_type_embeddings = Embedding(
+            num_embeddings=embedding_config.type_vocab_size,
+            embedding_dim=embedding_config.embedding_dim,
         )
-        self.position_embeddings = torch.nn.Embedding(
-            num_embeddings=config.max_position_embeddings,
-            embedding_dim=config.embedding_dim,
+        self.position_embeddings = Embedding(
+            num_embeddings=embedding_config.max_position_embeddings,
+            embedding_dim=embedding_config.embedding_dim,
         )
 
-        self.layer_norm = torch.nn.LayerNorm(
-            config.embedding_dim, eps=config.layer_norm_eps
+        if embedding_config.embedding_dim != layer_config.hidden_size:
+            self.projection = Linear(
+                embedding_config.embedding_dim, layer_config.hidden_size
+            )
+        else:
+            self.projection = None
+
+        self.layer_norm = LayerNorm(
+            embedding_config.embedding_dim, eps=embedding_config.layer_norm_eps
         )
-        self.dropout = torch.nn.Dropout(p=config.dropout_prob)
+        self.dropout = Dropout(p=embedding_config.dropout_prob)
 
     def _get_position_ids(self, x: Tensor) -> Tensor:
         return torch.arange(x.shape[1], device=x.device).expand(1, -1)
@@ -52,4 +62,9 @@ class BertEmbeddings(Module):
         embedding_sum += token_type_embeddings
         embedding_sum += position_embeddings
         normalized = self.layer_norm(embedding_sum)
-        return self.dropout(normalized)
+        embeddings = self.dropout(normalized)
+
+        if self.projection is not None:
+            return self.projection(embeddings)
+        else:
+            return embeddings

--- a/curated_transformers/models/bert/encoder.py
+++ b/curated_transformers/models/bert/encoder.py
@@ -18,7 +18,7 @@ class BertEncoder(Module):
     ):
         super().__init__()
 
-        self.embeddings = BertEmbeddings(config.embedding)
+        self.embeddings = BertEmbeddings(config.embedding, config.layer)
         self.padding_idx = config.padding_idx
         self.max_seq_len = config.model_max_length
         self.layers = torch.nn.ModuleList(

--- a/curated_transformers/models/hf_util.py
+++ b/curated_transformers/models/hf_util.py
@@ -123,8 +123,12 @@ def _convert_albert_base_state(
     out["embeddings.layer_norm.bias"] = params["embeddings.LayerNorm.bias"]
 
     # Embedding projection
-    out["projection.weight"] = params["encoder.embedding_hidden_mapping_in.weight"]
-    out["projection.bias"] = params["encoder.embedding_hidden_mapping_in.bias"]
+    out["embeddings.projection.weight"] = params[
+        "encoder.embedding_hidden_mapping_in.weight"
+    ]
+    out["embeddings.projection.bias"] = params[
+        "encoder.embedding_hidden_mapping_in.bias"
+    ]
 
     return _merge_qkv_albert(out)
 

--- a/curated_transformers/models/roberta/embeddings.py
+++ b/curated_transformers/models/roberta/embeddings.py
@@ -2,15 +2,20 @@ from typing import Optional
 from torch.nn import Module
 from torch import Tensor
 
-from ..bert import BertEmbeddings, BertEmbeddingConfig
-from .config import RobertaConfig
+from ..bert import BertEmbeddings, BertEmbeddingConfig, BertLayerConfig
 
 
 class RobertaEmbeddings(Module):
-    def __init__(self, config: BertEmbeddingConfig, *, padding_idx: int) -> None:
+    def __init__(
+        self,
+        embedding_config: BertEmbeddingConfig,
+        layer_config: BertLayerConfig,
+        *,
+        padding_idx: int
+    ) -> None:
         super().__init__()
 
-        self.inner = BertEmbeddings(config)
+        self.inner = BertEmbeddings(embedding_config, layer_config)
         self.padding_idx = padding_idx
 
     def _get_position_ids(self, x: Tensor) -> Tensor:

--- a/curated_transformers/models/roberta/encoder.py
+++ b/curated_transformers/models/roberta/encoder.py
@@ -17,7 +17,7 @@ class RobertaEncoder(Module):
         super().__init__()
 
         self.embeddings = RobertaEmbeddings(
-            config.embedding, padding_idx=config.padding_idx
+            config.embedding, config.layer, padding_idx=config.padding_idx
         )
         self.padding_idx = config.padding_idx
         self.max_seq_len = config.model_max_length


### PR DESCRIPTION
This change moves the embedding projection from AlbertEncoder to BertEmbeddings. The projection it activated when the embedding and hidden sizes differ.

By moving the projection to the embedding layer, we can support distallation with an embedding projection without fully switching to the ALBERT model. Furthermore, the projection can be used to compress embedding layers of existing BERT/RoBERTa models.