### PR TITLE
`mypy` fixes

### DIFF
--- a/curated_transformers/_compat.py
+++ b/curated_transformers/_compat.py
@@ -3,13 +3,13 @@ try:
 
     has_hf_transformers = True
 except ImportError:
-    transformers = None
+    transformers = None  # type: ignore
     has_hf_transformers = False
 
 try:
-    import huggingface_hub
+    import huggingface_hub  # type: ignore
 
     has_huggingface_hub = True
 except ImportError:
-    huggingface_hub = None
+    huggingface_hub = None  # type: ignore
     has_huggingface_hub = False

--- a/curated_transformers/cli/quantize.py
+++ b/curated_transformers/cli/quantize.py
@@ -11,8 +11,8 @@ from torch.nn import Embedding, Linear, Module, MSELoss
 from torch.quantization import qconfig
 from typer import Argument as Arg, Option
 
-from ..models.torchscript_wrapper import to_torchscript_wrapper
-from ..pipe import Transformer
+from ..models.torchscript_wrapper import to_torchscript_wrapper  # type: ignore
+from ..pipe import Transformer  # type: ignore
 
 
 MODULE_QUANTIZERS = {
@@ -101,7 +101,7 @@ def quantize_dynamic(
         quantize_types[Embedding] = MODULE_QUANTIZERS[Embedding]
 
     if not skip_linear:
-        quantize_types[Linear] = MODULE_QUANTIZERS[Linear]
+        quantize_types[Linear] = MODULE_QUANTIZERS[Linear]  # type: ignore
 
     quantized_model = torch.quantization.quantize_dynamic(
         pytorch_model,

--- a/curated_transformers/models/bert/embeddings.py
+++ b/curated_transformers/models/bert/embeddings.py
@@ -30,7 +30,7 @@ class BertEmbeddings(Module):
                 embedding_config.embedding_dim, layer_config.hidden_size
             )
         else:
-            self.projection = None
+            self.projection = None  # type: ignore
 
         self.layer_norm = LayerNorm(
             embedding_config.embedding_dim, eps=embedding_config.layer_norm_eps

--- a/curated_transformers/models/bert/encoder.py
+++ b/curated_transformers/models/bert/encoder.py
@@ -34,7 +34,7 @@ class BertEncoder(Module):
     def forward(
         self,
         input_ids: Tensor,
-        attention_mask: Optional[Tensor] = None,
+        attention_mask: Optional[AttentionMask] = None,
         token_type_ids: Optional[Tensor] = None,
     ) -> PyTorchTransformerOutput:
         """

--- a/curated_transformers/models/output.py
+++ b/curated_transformers/models/output.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, TypeVar
+from typing import List, Optional, TypeVar, Generic
 from dataclasses import dataclass
 import torch
 from torch import Tensor
@@ -46,7 +46,7 @@ class PyTorchTransformerOutput:
 
 
 @dataclass
-class TransformerModelOutput:
+class TransformerModelOutput(Generic[TrfOutputT]):
     """Wrapper for PyTorchTransformerOutput consumed by downstream non-PyTorch components.
     Also acts as the accumulator for the outputs of subsequent models in the Transformer pipeline."""
 

--- a/curated_transformers/models/remove_eos_bos.py
+++ b/curated_transformers/models/remove_eos_bos.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Tuple, cast
 from thinc.api import Model, Ragged
 
 from .output import TransformerModelOutput
@@ -41,16 +41,19 @@ def remove_bos_eos_forward(
 
         def _apply_to_layers(input: List[List[Ragged]], output: List[List[Ragged]]):
             for inner_dY in input:
-                inner_dX = []
+                inner_dX: List[Ragged] = []
                 _apply_to_layer(inner_dY, inner_dX)
                 output.append(inner_dX)
 
-        dX = []
         if isinstance(dY[0], list):
-            _apply_to_layers(dY, dX)
+            nested_list = cast(List[List[Ragged]], dY)
+            dX_nested: List[List[Ragged]] = []
+            _apply_to_layers(nested_list, dX_nested)
+            return dX_nested
         else:
-            _apply_to_layer(dY, dX)
-
-        return dX
+            flat_list = cast(List[Ragged], dY)
+            dX_flat: List[Ragged] = []
+            _apply_to_layer(flat_list, dX_flat)
+            return dX_flat
 
     return X, backprop

--- a/curated_transformers/models/torchscript_wrapper.py
+++ b/curated_transformers/models/torchscript_wrapper.py
@@ -1,6 +1,6 @@
 from typing import Any, Callable, Optional
 from io import BytesIO
-import srsly
+import srsly  # type: ignore
 from thinc.api import Model, PyTorchGradScaler, PyTorchShim, get_torch_default_device
 from thinc.layers.pytorchwrapper import convert_pytorch_default_inputs
 from thinc.layers.pytorchwrapper import convert_pytorch_default_outputs

--- a/curated_transformers/models/transformer_model.py
+++ b/curated_transformers/models/transformer_model.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Callable, Any
+from typing import Dict, List, Mapping, Optional, Tuple, Callable, Any, cast
 from pathlib import Path
 from functools import partial
 from spacy.tokens import Doc
@@ -355,7 +355,7 @@ def build_transformer_model_v1(
         [TorchTransformerModelT],
         SpanExtractorModelT,
     ],
-    transformer: TransformerModelT,
+    transformer: TorchTransformerModelT,
     piece_encoder: Tok2PiecesModelT,
     piece_adapter: PieceAdapterModelT = None,
 ) -> TransformerModelT:
@@ -387,7 +387,7 @@ def build_transformer_model_v1(
         transformer_model_forward,
         init=transformer_model_init,
         layers=layers,
-        refs=refs,
+        refs=refs,  # type: ignore
         attrs={
             "replace_listener": _replace_listener,
             "replace_listener_cfg": _replace_listener_cfg,
@@ -513,7 +513,9 @@ def _convert_outputs(
             for i, len in enumerate(input_lens)
         ]
 
-    Y = [[torch2xp(layer, ops=ops) for layer in output] for output in Yt]
+    Y = [
+        [cast(Floats2d, torch2xp(layer, ops=ops)) for layer in output] for output in Yt
+    ]
     output = TransformerModelOutput(outputs=Y, last_layer_only=not all_layer_outputs)
 
     def convert_for_torch_backward(dY: List[List[Floats2d]]):

--- a/curated_transformers/tokenization/bbpe_encoder.py
+++ b/curated_transformers/tokenization/bbpe_encoder.py
@@ -1,8 +1,8 @@
 from typing import Callable, Optional, Tuple
 from pathlib import Path
 
-from cutlery import ByteBPEProcessor
-import srsly
+from cutlery import ByteBPEProcessor  # type: ignore
+import srsly  # type: ignore
 from thinc.api import Model, Ragged, deserialize_attr, serialize_attr
 
 from .types import (

--- a/curated_transformers/tokenization/hf_loader.py
+++ b/curated_transformers/tokenization/hf_loader.py
@@ -39,7 +39,7 @@ def _convert_encoder(
         tokenizer,
         (transformers.XLMRobertaTokenizerFast, transformers.CamembertTokenizerFast),
     ):
-        return _convert_sentencepiece_encoder(model, tokenizer)
+        return _convert_sentencepiece_encoder(model, tokenizer)  # type: ignore
 
     raise ValueError(
         f"Loading from the '{type(tokenizer)}' huggingface tokenizer is not supported"
@@ -53,14 +53,14 @@ def _convert_byte_bpe_encoder(
     # Seems like we cannot get the vocab file name for a RoBERTa vocabulary? And
     # neither the merges from the fast tokenizer. So we'll get them from the
     # JSON serialization.
-    serialized = tokenizer.backend_tokenizer.to_str(True)
+    serialized = tokenizer.backend_tokenizer.to_str(True)  # type: ignore
     deserialized = json.loads(serialized)
     vocab_merges = deserialized["model"]
     merges = [tuple(merge.split(" ")) for merge in vocab_merges["merges"]]
     model.attrs["byte_bpe_processor"] = ByteBPEProcessor(vocab_merges["vocab"], merges)
-    model.attrs["bos_piece"] = tokenizer.bos_token
-    model.attrs["eos_piece"] = tokenizer.eos_token
-    model.attrs["unk_piece"] = tokenizer.unk_token
+    model.attrs["bos_piece"] = tokenizer.bos_token  # type: ignore
+    model.attrs["eos_piece"] = tokenizer.eos_token  # type: ignore
+    model.attrs["unk_piece"] = tokenizer.unk_token  # type: ignore
 
     return model
 
@@ -70,7 +70,7 @@ def _convert_sentencepiece_encoder(
     tokenizer: "transformers.RobertaTokenizerFast",
 ) -> Tok2PiecesModelT:
     model.attrs["sentencepiece_processor"] = SentencePieceProcessor.from_file(
-        tokenizer.vocab_file
+        tokenizer.vocab_file  # type: ignore
     )
     return model
 
@@ -80,12 +80,12 @@ def _convert_wordpiece_encoder(
 ) -> Tok2PiecesModelT:
     # Seems like we cannot get the vocab file name for a BERT vocabulary? So,
     # instead, copy the vocabulary.
-    vocab = [None] * tokenizer.vocab_size
-    for piece, idx in tokenizer.vocab.items():
+    vocab = [None] * tokenizer.vocab_size  # type: ignore
+    for piece, idx in tokenizer.vocab.items():  # type: ignore
         vocab[idx] = piece
     model.attrs["wordpiece_processor"] = WordPieceProcessor(vocab)
-    model.attrs["bos_piece"] = tokenizer.cls_token
-    model.attrs["eos_piece"] = tokenizer.sep_token
-    model.attrs["unk_piece"] = tokenizer.unk_token
+    model.attrs["bos_piece"] = tokenizer.cls_token  # type: ignore
+    model.attrs["eos_piece"] = tokenizer.sep_token  # type: ignore
+    model.attrs["unk_piece"] = tokenizer.unk_token  # type: ignore
 
     return model

--- a/curated_transformers/tokenization/sentencepiece_encoder.py
+++ b/curated_transformers/tokenization/sentencepiece_encoder.py
@@ -1,6 +1,6 @@
 from typing import Callable, Optional, Tuple
 from pathlib import Path
-from cutlery import SentencePieceProcessor
+from cutlery import SentencePieceProcessor  # type: ignore
 from thinc.api import Model, Ragged, deserialize_attr, serialize_attr
 
 from .types import (

--- a/curated_transformers/tokenization/wordpiece_encoder.py
+++ b/curated_transformers/tokenization/wordpiece_encoder.py
@@ -1,7 +1,7 @@
 from typing import Callable, Optional, Tuple
 from pathlib import Path
 
-from cutlery import WordPieceProcessor
+from cutlery import WordPieceProcessor  # type:ignore
 from thinc.api import Model, Ragged, deserialize_attr, serialize_attr
 
 from .types import (

--- a/curated_transformers/util.py
+++ b/curated_transformers/util.py
@@ -1,4 +1,4 @@
-from typing import List, Set, Iterable
+from typing import Any, List, Set, Iterable
 import itertools
 import thinc
 
@@ -38,8 +38,8 @@ def batch_by_length(seqs, max_words: int) -> List[List[int]]:
     return batches
 
 
-def all_equal(iterable: Iterable) -> bool:
+def all_equal(iterable: Iterable[Any]) -> bool:
     """Return True if all the elements are equal to each other
     (or if the input is an empty sequence), False otherwise."""
     g = itertools.groupby(iterable)
-    return next(g, True) and not next(g, False)
+    return next(g, True) and not next(g, False)  # type: ignore

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,3 +47,6 @@ universal = false
 
 [sdist]
 formats = gztar
+
+[mypy]
+exclude = tests


### PR DESCRIPTION
Unfortunately, a bunch of `# type: ignore` annotations needed to be added due to the type error stemming from external library code (e.g: `transformers`)that couldn't be easily worked around/fixed on our end (without a fair amount of unwieldy/hacky casting).

Also fixes the output of `Transformer.predict` for input `Doc`s with no tokens.