### PR TITLE
Fix slow tests

### DIFF
--- a/curated_transformers/tests/test_pipe.py
+++ b/curated_transformers/tests/test_pipe.py
@@ -475,6 +475,7 @@ cfg_string_gradual_unfreezing = (
 
 
 @pytest.mark.slow
+@pytest.mark.xfail(reason="fails until spaCy supports after_update callbacks")
 @pytest.mark.skipif(not has_hf_transformers, reason="requires 🤗 transformers")
 def test_gradual_transformer_unfreezing(test_dir):
     def wrapped_callback():


### PR DESCRIPTION
Slow tests are failing because the configuration of the layer freezing
test cannot be validated because the `after_update` callback is not
yet in spaCy.
